### PR TITLE
[Feature] DB 환경 구축 및 주가 데이터 적재

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -11,10 +11,3 @@ src/main/resources/application.yml
 
 # Mac
 .DS_Store
-
-
-이거 그건데
-프로젝트 아예 새로 만든거
-ㄴㄴㄴ
-깡통
-ㅇㅋ

--- a/backend/src/main/java/com/capstone/survival/CsvImportRunner.java
+++ b/backend/src/main/java/com/capstone/survival/CsvImportRunner.java
@@ -1,0 +1,23 @@
+package com.capstone.survival;
+
+import com.capstone.survival.service.CsvImportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CsvImportRunner implements ApplicationRunner {
+
+    private final CsvImportService csvImportService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("===== CSV 데이터 적재 시작 =====");
+        csvImportService.importAll();
+        log.info("===== CSV 데이터 적재 완료 =====");
+    }
+}

--- a/backend/src/main/java/com/capstone/survival/InvestSurvivalApplication.java
+++ b/backend/src/main/java/com/capstone/survival/InvestSurvivalApplication.java
@@ -1,4 +1,4 @@
-package com.capstone.survival.invest_survival;
+package com.capstone.survival;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/backend/src/main/java/com/capstone/survival/entity/StockPrice.java
+++ b/backend/src/main/java/com/capstone/survival/entity/StockPrice.java
@@ -1,0 +1,54 @@
+package com.capstone.survival.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "stock_price",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"ticker", "trade_date"})
+)
+@Getter
+@NoArgsConstructor
+public class StockPrice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String ticker;       // ex) ^SPX, ^NDX, ^KOSPI
+
+    @Column(name = "trade_date", nullable = false)
+    private LocalDate tradeDate;
+
+    private Double open;
+    private Double high;
+    private Double low;
+
+    @Column(nullable = false)
+    private Double close;
+
+    @Column(name = "adj_close")
+    private Double adjClose;
+
+    private Long volume;
+
+    public StockPrice(String ticker, LocalDate tradeDate,
+                      Double open, Double high, Double low,
+                      Double close, Double adjClose, Long volume) {
+        this.ticker = ticker;
+        this.tradeDate = tradeDate;
+        this.open = open;
+        this.high = high;
+        this.low = low;
+        this.close = close;
+        this.adjClose = adjClose;
+        this.volume = volume;
+    }
+}
+
+

--- a/backend/src/main/java/com/capstone/survival/repository/StockPriceRepository.java
+++ b/backend/src/main/java/com/capstone/survival/repository/StockPriceRepository.java
@@ -1,0 +1,23 @@
+package com.capstone.survival.repository;
+
+import com.capstone.survival.entity.StockPrice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface StockPriceRepository extends JpaRepository<StockPrice, Long> {
+
+    // 중복 체크용 (기존)
+    boolean existsByTickerAndTradeDate(String ticker, LocalDate tradeDate);
+
+    // 시나리오 기간 주가 조회 (게임 시작 시 사용)
+    List<StockPrice> findByTickerAndTradeDateBetweenOrderByTradeDate(
+            String ticker, LocalDate startDate, LocalDate endDate
+    );
+
+    // 특정 날짜 이후 주가 조회 (라운드 진행 시 사용)
+    List<StockPrice> findByTickerAndTradeDateGreaterThanEqualOrderByTradeDate(
+            String ticker, LocalDate startDate
+    );
+}

--- a/backend/src/main/java/com/capstone/survival/service/CsvImportService.java
+++ b/backend/src/main/java/com/capstone/survival/service/CsvImportService.java
@@ -1,0 +1,116 @@
+package com.capstone.survival.service;
+
+import com.capstone.survival.entity.StockPrice;
+import com.capstone.survival.repository.StockPriceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CsvImportService {
+
+    private final StockPriceRepository stockPriceRepository;
+
+    // CSV 파일 경로와 ticker 매핑
+    private static final Map<String, String> CSV_FILES = Map.of(
+            "^SPX",   System.getProperty("user.home") + "/Library/Mobile Documents/com~apple~CloudDocs/Documents/202330377/4-1/capstone/data/^spx_d.csv",
+            "^NDX",   System.getProperty("user.home") + "/Library/Mobile Documents/com~apple~CloudDocs/Documents/202330377/4-1/capstone/data/^ndx_d.csv",
+            "^KOSPI", System.getProperty("user.home") + "/Library/Mobile Documents/com~apple~CloudDocs/Documents/202330377/4-1/capstone/data/^kospi_d.csv",
+            "XAUUSD", System.getProperty("user.home") + "/Library/Mobile Documents/com~apple~CloudDocs/Documents/202330377/4-1/capstone/data/xauusd_d.csv"
+    );
+
+    /**
+     * 전체 CSV 파일 일괄 임포트
+     * 앱 첫 실행 시 한 번만 돌리면 됨
+     */
+    public void importAll() {
+        for (Map.Entry<String, String> entry : CSV_FILES.entrySet()) {
+            String ticker  = entry.getKey();
+            String csvPath = entry.getValue();
+            try {
+                log.info("[임포트 시작] ticker={}", ticker);
+                int count = importCsv(ticker, csvPath);
+                log.info("[임포트 완료] ticker={}, 저장건수={}", ticker, count);
+            } catch (Exception e) {
+                log.error("[임포트 실패] ticker={}, error={}", ticker, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * 단일 CSV 파일 파싱 후 DB 저장
+     * STOOQ CSV 형식: Date,Open,High,Low,Close,Volume
+     */
+    @Transactional
+    public int importCsv(String ticker, String csvPath) throws Exception {
+
+        List<StockPrice> batch = new ArrayList<>();
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        try (BufferedReader br = new BufferedReader(new FileReader(csvPath))) {
+            String line;
+            boolean isHeader = true;
+
+            while ((line = br.readLine()) != null) {
+                // 첫 줄 헤더 스킵
+                if (isHeader) { isHeader = false; continue; }
+                // 빈 줄 스킵
+                if (line.isBlank()) continue;
+
+                String[] cols = line.split(",");
+                if (cols.length < 5) continue;
+
+                LocalDate date = LocalDate.parse(cols[0].trim(), fmt);
+
+                // 중복 데이터 스킵
+                if (stockPriceRepository.existsByTickerAndTradeDate(ticker, date)) continue;
+
+                Double open   = parseDouble(cols[1]);
+                Double high   = parseDouble(cols[2]);
+                Double low    = parseDouble(cols[3]);
+                Double close  = parseDouble(cols[4]);
+                // STOOQ는 Adj Close 없고 Volume이 5번째
+                Double adjClose = null;
+                Long   volume = cols.length > 5 ? parseLong(cols[5]) : null;
+
+                if (close == null) continue; // close 없으면 스킵
+
+                batch.add(new StockPrice(ticker, date, open, high, low, close, adjClose, volume));
+
+                // 1000건마다 배치 저장 (메모리 관리)
+                if (batch.size() >= 1000) {
+                    stockPriceRepository.saveAll(batch);
+                    batch.clear();
+                }
+            }
+
+            // 남은 데이터 저장
+            if (!batch.isEmpty()) {
+                stockPriceRepository.saveAll(batch);
+            }
+        }
+
+        return (int) stockPriceRepository.count();
+    }
+
+    private Double parseDouble(String val) {
+        try { return Double.parseDouble(val.trim()); }
+        catch (Exception e) { return null; }
+    }
+
+    private Long parseLong(String val) {
+        try { return Long.parseLong(val.trim()); }
+        catch (Exception e) { return null; }
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/survivor_db
+    username: postgres
+    password: 1234
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## #️⃣연관된 이슈> #1

## 📝작업 내용> 
PostgreSQL DB 환경을 구축하고 S&P500, NASDAQ, 코스피, 금(XAUUSD) 30년치 주가 데이터를 적재했습니다.

## 📁 추가된 파일
| 파일 | 역할 |
|------|------|
| `StockPrice.java` | 주가 데이터 DB 엔티티 |
| `StockPriceRepository.java` | 주가 데이터 DB 조회 |
| `CsvImportService.java` | CSV 파싱 → DB 적재 서비스 |
| `CsvImportRunner.java` | 앱 시작 시 CSV 자동 적재 |

## 🔍 주요 로직

### StockPrice 엔티티
```java
@Entity
@Table(name = "stock_price")
public class StockPrice {
    @Id @GeneratedValue
    private Long id;
    private String ticker;      // ^SPX, ^NDX, ^KOSPI, XAUUSD
    private LocalDate tradeDate;
    private Double open, high, low, close, adjClose;
    private Long volume;
}
```

### 배치 INSERT (1,000건 단위)
```java
if (batch.size() >= 1000) {
    repository.saveAll(batch); // DB 왕복 최소화
    batch.clear();
}
```

### 중복 방지
```java
if (repository.existsByTickerAndTradeDate(ticker, price.getTradeDate())) {
    continue; // 이미 있으면 스킵
}
```

## ✅ 테스트 결과
| 케이스 | 결과 |
|--------|------|
| ^SPX 데이터 적재 | ✅ 7,802건 |
| ^NDX 데이터 적재 | ✅ 7,802건 |
| ^KOSPI 데이터 적재 | ✅ 7,800건 |
| XAUUSD 데이터 적재 | ✅ 약 7,800건 |
| 중복 실행 시 스킵 | ✅ |

## 📊 적재 결과
| 지수 | 심볼 | 기간 | 건수 |
|------|------|------|------|
| S&P 500 | ^SPX | 1995 ~ 2025 | 7,802건 |
| NASDAQ | ^NDX | 1995 ~ 2025 | 7,802건 |
| 코스피 | ^KOSPI | 1995 ~ 2025 | 7,800건 |
| 금 | XAUUSD | 1995 ~ 2025 | 약 7,800건 |
| **합계** | | | **약 31,200건** |

## 🔗 연관된 이슈
close #1