### PR TITLE
[Feature] StockPrice 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/capstone/survival/controller/StockPriceController.java
+++ b/backend/src/main/java/com/capstone/survival/controller/StockPriceController.java
@@ -1,0 +1,42 @@
+package com.capstone.survival.controller;
+
+import com.capstone.survival.dto.ApiResponse;
+import com.capstone.survival.entity.StockPrice;
+import com.capstone.survival.repository.StockPriceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@CrossOrigin(origins = "*")
+@RequestMapping("/api/stock")
+@RequiredArgsConstructor
+public class StockPriceController {
+
+    private final StockPriceRepository repository;
+
+    // GET http://localhost:8080/api/stock/price?ticker=%5ESPX&startDate=2008-01-01&endDate=2008-12-31
+    @GetMapping("/price")
+    public ApiResponse<List<StockPrice>> getPrice(
+            @RequestParam String ticker,
+            @RequestParam String startDate,
+            @RequestParam String endDate
+    ) {
+        List<StockPrice> result = repository
+                .findByTickerAndTradeDateBetweenOrderByTradeDate(
+                        ticker,
+                        LocalDate.parse(startDate),
+                        LocalDate.parse(endDate)
+                );
+        return ApiResponse.ok(result);
+    }
+
+    // GET /api/stock/tickers
+    @GetMapping("/tickers")
+    public ApiResponse<List<String>> getTickers() {
+        List<String> tickers = List.of("^SPX", "^NDX", "^KOSPI", "XAUUSD");
+        return ApiResponse.ok(tickers);
+    }
+}

--- a/backend/src/main/java/com/capstone/survival/dto/ApiResponse.java
+++ b/backend/src/main/java/com/capstone/survival/dto/ApiResponse.java
@@ -1,0 +1,20 @@
+package com.capstone.survival.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private boolean success;
+    private T data;
+    private String message;
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, data, "OK");
+    }
+
+    public static <T> ApiResponse<T> fail(String message) {
+        return new ApiResponse<>(false, null, message);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈> #3

## 📝작업 내용> 
Flutter에서 주가 데이터를 조회할 수 있는 REST API를 구현했습니다.
모든 API 응답에 공통 형식을 적용하는 ApiResponse DTO도 함께 구현했습니다.

## 📁 추가된 파일
| 파일 | 역할 |
|------|------|
| `ApiResponse.java` | 공통 응답 형식 DTO |
| `StockPriceController.java` | 주가 데이터 조회 REST API |

## 🔍 주요 로직

### ApiResponse - 공통 응답 형식
```java
@Getter
@AllArgsConstructor
public class ApiResponse<T> {
    private boolean success;
    private T data;
    private String message;

    public static <T> ApiResponse<T> ok(T data) {
        return new ApiResponse<>(true, data, "OK");
    }
    public static <T> ApiResponse<T> fail(String message) {
        return new ApiResponse<>(false, null, message);
    }
}
```

### 기간별 주가 조회
```java
// GET /api/stock/price?ticker=^SPX&startDate=2008-01-01&endDate=2008-12-31
@GetMapping("/price")
public ApiResponse<List<StockPrice>> getPrice(
    @RequestParam String ticker,
    @RequestParam String startDate,
    @RequestParam String endDate
) {
    List<StockPrice> result = repository
        .findByTickerAndTradeDateBetweenOrderByTradeDate(
            ticker,
            LocalDate.parse(startDate),
            LocalDate.parse(endDate)
        );
    return ApiResponse.ok(result);
}
```

## 📡 API 명세

### GET /api/stock/tickers
지수 목록 반환

**Response**
```json
{
  "success": true,
  "data": ["^SPX", "^NDX", "^KOSPI", "XAUUSD"],
  "message": "OK"
}
```

### GET /api/stock/price
기간별 주가 데이터 반환

**Query Parameters**
| 파라미터 | 타입 | 예시 |
|----------|------|------|
| ticker | String | ^SPX |
| startDate | String | 2008-01-01 |
| endDate | String | 2008-12-31 |

**Response**
```json
{
  "success": true,
  "data": [
    {
      "ticker": "^SPX",
      "tradeDate": "2008-01-02",
      "open": 1447.16,
      "close": 1411.63,
      "high": 1450.23,
      "low": 1403.97
    }
  ],
  "message": "OK"
}
```

## ✅ 테스트 결과
| 케이스 | 결과 |
|--------|------|
| GET /api/stock/tickers | ✅ 4개 지수 정상 반환 |
| GET /api/stock/price (정상 조회) | ✅ 주가 데이터 정상 반환 |
| GET /api/stock/price (파라미터 누락) | ✅ 400 Bad Request 반환 |

## 🔗 연관된 이슈
close #3