### PR TITLE
[Feature] 카드 선택 API 구현

### DIFF
--- a/backend/src/main/java/com/capstone/survival/controller/GameController.java
+++ b/backend/src/main/java/com/capstone/survival/controller/GameController.java
@@ -30,4 +30,17 @@ public class GameController {
     public ApiResponse<?> startGame(@RequestBody Map<String, Integer> request) {
         return ApiResponse.ok(gameService.startGame(request.get("scenarioId")));
     }
+
+    // POST /game/round/action
+    @PostMapping("/round/action")
+    public ApiResponse<?> selectCard(
+            @RequestBody Map<String, Object> request) {
+        String sessionId = (String) request.get("sessionId");
+        Integer round = (Integer) request.get("round");
+        Integer cardId = (Integer) request.get("cardId");
+
+        return ApiResponse.ok(
+                gameService.selectCard(sessionId, round, cardId)
+        );
+    }
 }

--- a/backend/src/main/java/com/capstone/survival/entity/Card.java
+++ b/backend/src/main/java/com/capstone/survival/entity/Card.java
@@ -1,0 +1,20 @@
+package com.capstone.survival.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "card")
+@Getter
+@NoArgsConstructor
+public class Card {
+
+    @Id
+    private Integer id;
+
+    private String name;       // "거인의 어깨"
+    private String ticker;     // "^SPX"
+    private Double ratio;      // 0.3 (자산의 30%)
+    private String description; // "현재 자산의 30%로 S&P500 즉시 매수"
+}

--- a/backend/src/main/java/com/capstone/survival/entity/GameSession.java
+++ b/backend/src/main/java/com/capstone/survival/entity/GameSession.java
@@ -22,6 +22,11 @@ public class GameSession {
     private Long initialAsset;
     private String status; // PLAYING, FINISHED
     private String gameStartDate;
+    // 기존 필드들 아래에 추가
+    private Long cash;              // 현재 현금
+    private Double spxShares;       // 보유 SPX 수량
+    private Integer currentRound;   // 현재 라운드
+    private String appliedCards;    // 적용된 카드 목록 "1,2"
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -37,5 +42,18 @@ public class GameSession {
         this.status = "PLAYING";
         this.gameStartDate = gameStartDate;
         this.createdAt = LocalDateTime.now();
+        this.cash = 10_000_000L;  // 초기 현금 = 초기 자산
+        this.spxShares = 0.0;
+        this.currentRound = 1;
+        this.appliedCards = "";
+    }
+
+    // 상태 업데이트 메서드 추가
+    public void update(Long cash, Double spxShares,
+                       Integer currentRound, String appliedCards) {
+        this.cash = cash;
+        this.spxShares = spxShares;
+        this.currentRound = currentRound;
+        this.appliedCards = appliedCards;
     }
 }

--- a/backend/src/main/java/com/capstone/survival/repository/CardRepository.java
+++ b/backend/src/main/java/com/capstone/survival/repository/CardRepository.java
@@ -1,0 +1,7 @@
+package com.capstone.survival.repository;
+
+import com.capstone.survival.entity.Card;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CardRepository extends JpaRepository<Card, Integer> {
+}

--- a/backend/src/main/java/com/capstone/survival/service/GameService.java
+++ b/backend/src/main/java/com/capstone/survival/service/GameService.java
@@ -1,8 +1,10 @@
 package com.capstone.survival.service;
 
+import com.capstone.survival.entity.Card;
 import com.capstone.survival.entity.GameSession;
 import com.capstone.survival.entity.Scenario;
 import com.capstone.survival.entity.StockPrice;
+import com.capstone.survival.repository.CardRepository;
 import com.capstone.survival.repository.GameSessionRepository;
 import com.capstone.survival.repository.ScenarioRepository;
 import com.capstone.survival.repository.StockPriceRepository;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,8 +22,16 @@ public class GameService {
     private final GameSessionRepository sessionRepository;
     private final ScenarioRepository scenarioRepository;
     private final StockPriceRepository stockPriceRepository;
+    private final CardRepository cardRepository;
 
+    // 카드 선택 라운드 고정
+    private static final List<Integer> CARD_SELECT_ROUNDS = List.of(1, 25, 50, 75);
+
+    // =============================================
+    // 게임 시작
+    // =============================================
     public Map<String, Object> startGame(Integer scenarioId) {
+
         // 1. 시나리오 조회
         Scenario scenario = scenarioRepository.findById(scenarioId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 시나리오입니다"));
@@ -33,7 +44,7 @@ public class GameService {
                         LocalDate.parse(scenario.getEndDate())
                 );
 
-        if (priceList.size() < 10) {
+        if (priceList.size() < 100) {
             throw new IllegalStateException("주가 데이터가 부족합니다");
         }
 
@@ -48,19 +59,127 @@ public class GameService {
         );
         sessionRepository.save(session);
 
-        // 4. 10라운드 데이터 생성
+        // 4. 1라운드 데이터만 반환 (카드 선택해야 하니까)
+        StockPrice first = priceList.get(0);
+
+        Map<String, Object> priceData = new LinkedHashMap<>();
+        priceData.put("ticker", first.getTicker());
+        priceData.put("open", first.getOpen());
+        priceData.put("close", first.getClose());
+        priceData.put("high", first.getHigh());
+        priceData.put("low", first.getLow());
+        priceData.put("changeRate", 0.0); // 첫 라운드는 비교 대상 없음
+
+        Map<String, Object> firstRound = new LinkedHashMap<>();
+        firstRound.put("round", 1);
+        firstRound.put("date", first.getTradeDate().toString());
+        firstRound.put("priceData", List.of(priceData));
+
+        // 5. 응답 반환
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("sessionId", sessionId);
+        response.put("scenarioTitle", scenario.getTitle());
+        response.put("totalRounds", 100);
+        response.put("initialAsset", 10_000_000L);
+        response.put("cardSelectRounds", CARD_SELECT_ROUNDS);
+        response.put("rounds", List.of(firstRound));
+
+        return response;
+    }
+
+    // =============================================
+    // 카드 선택
+    // =============================================
+    public Map<String, Object> selectCard(
+            String sessionId, Integer round, Integer cardId) {
+
+        // 1. 세션 조회
+        GameSession session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다"));
+
+        // 2. 카드 조회
+        Card card = cardRepository.findById(cardId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카드입니다"));
+
+        // 3. 중복 카드 체크
+        List<Integer> appliedCardIds = getAppliedCardIds(session);
+        if (appliedCardIds.contains(cardId)) {
+            throw new IllegalArgumentException("이미 선택한 카드입니다");
+        }
+
+        // 4. 카드 효과 적용 (매수)
+        double currentClose = getPriceAtRound(session, round);
+        double buyAmount = session.getCash() * card.getRatio();
+        double newShares = session.getSpxShares() + (buyAmount / currentClose);
+        long newCash = (long)(session.getCash() - buyAmount);
+
+        // 5. 적용된 카드 목록 업데이트
+        appliedCardIds.add(cardId);
+        String newAppliedCards = appliedCardIds.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+
+        // 6. 다음 증강 라운드 계산
+        Integer nextEventRound = CARD_SELECT_ROUNDS.stream()
+                .filter(r -> r > round)
+                .findFirst()
+                .orElse(null);
+
+        // 7. 현재 라운드부터 다음 증강 직전까지 계산
+        int endRound = nextEventRound != null ? nextEventRound - 1 : 100;
+        List<Map<String, Object>> rounds = calculateRounds(
+                session, round, endRound, newCash, newShares
+        );
+
+        // 8. 세션 업데이트
+        session.update(newCash, newShares, endRound + 1, newAppliedCards);
+        sessionRepository.save(session);
+
+        // 9. 응답 반환
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("selectedCard", card.getName());
+        response.put("nextEventRound", nextEventRound);
+        response.put("rounds", rounds);
+
+        return response;
+    }
+
+    // =============================================
+    // 라운드별 자산 계산
+    // =============================================
+    private List<Map<String, Object>> calculateRounds(
+            GameSession session, int startRound, int endRound,
+            long cash, double shares) {
+
+        List<StockPrice> priceList = stockPriceRepository
+                .findByTickerAndTradeDateGreaterThanEqualOrderByTradeDate(
+                        session.getTicker(),
+                        LocalDate.parse(session.getGameStartDate())
+                );
+
         List<Map<String, Object>> rounds = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
+
+        for (int i = startRound - 1; i < endRound; i++) {
+            if (i >= priceList.size()) break;
+
             StockPrice current = priceList.get(i);
             StockPrice prev = i > 0 ? priceList.get(i - 1) : null;
 
             // 등락률 계산
             double changeRate = 0.0;
-            if (prev != null && prev.getClose() != null && prev.getClose() > 0) {
-                changeRate = (current.getClose() - prev.getClose()) / prev.getClose() * 100;
+            if (prev != null && prev.getClose() > 0) {
+                changeRate = (current.getClose() - prev.getClose())
+                        / prev.getClose() * 100;
                 changeRate = Math.round(changeRate * 100.0) / 100.0;
             }
 
+            // 자산 계산
+            long roundAsset = (long)(cash + shares * current.getClose());
+            double returnRate = (double)(roundAsset - session.getInitialAsset())
+                    / session.getInitialAsset() * 100;
+            returnRate = Math.round(returnRate * 100.0) / 100.0;
+
+            // priceData
             Map<String, Object> priceData = new LinkedHashMap<>();
             priceData.put("ticker", current.getTicker());
             priceData.put("open", current.getOpen());
@@ -69,22 +188,42 @@ public class GameService {
             priceData.put("low", current.getLow());
             priceData.put("changeRate", changeRate);
 
-            Map<String, Object> round = new LinkedHashMap<>();
-            round.put("round", i + 1);
-            round.put("date", current.getTradeDate().toString());
-            round.put("priceData", List.of(priceData));
+            // round
+            Map<String, Object> roundMap = new LinkedHashMap<>();
+            roundMap.put("round", i + 1);
+            roundMap.put("date", current.getTradeDate().toString());
+            roundMap.put("priceData", List.of(priceData));
+            roundMap.put("roundAsset", roundAsset);
+            roundMap.put("returnRate", returnRate);
 
-            rounds.add(round);
+            rounds.add(roundMap);
         }
 
-        // 5. 응답 반환
-        Map<String, Object> response = new LinkedHashMap<>();
-        response.put("sessionId", sessionId);
-        response.put("scenarioTitle", scenario.getTitle());
-        response.put("totalRounds", 10);
-        response.put("initialAsset", 10_000_000L);
-        response.put("rounds", rounds);
+        return rounds;
+    }
 
-        return response;
+    // =============================================
+    // 유틸 메서드
+    // =============================================
+
+    // 특정 라운드 종가 조회
+    private double getPriceAtRound(GameSession session, int round) {
+        List<StockPrice> priceList = stockPriceRepository
+                .findByTickerAndTradeDateGreaterThanEqualOrderByTradeDate(
+                        session.getTicker(),
+                        LocalDate.parse(session.getGameStartDate())
+                );
+        return priceList.get(round - 1).getClose();
+    }
+
+    // 적용된 카드 ID 목록 파싱
+    private List<Integer> getAppliedCardIds(GameSession session) {
+        if (session.getAppliedCards() == null
+                || session.getAppliedCards().isEmpty()) {
+            return new ArrayList<>();
+        }
+        return Arrays.stream(session.getAppliedCards().split(","))
+                .map(Integer::parseInt)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -12,3 +12,12 @@ ON CONFLICT (id) DO UPDATE SET
     ticker = EXCLUDED.ticker,
     start_date = EXCLUDED.start_date,
     end_date = EXCLUDED.end_date;
+
+INSERT INTO card (id, name, ticker, ratio, description)
+VALUES
+    (1, '거인의 어깨', '^SPX', 0.3, '현재 자산의 30%로 S&P500 즉시 매수')
+    ON CONFLICT (id) DO UPDATE SET
+    name = EXCLUDED.name,
+                            ticker = EXCLUDED.ticker,
+                            ratio = EXCLUDED.ratio,
+                            description = EXCLUDED.description;


### PR DESCRIPTION
## #️⃣연관된 이슈> #11

## 📝작업 내용> 
카드를 선택하면 해당 라운드부터 다음 증강 직전까지의
자산 변화를 계산해서 반환하는 API를 구현했습니다.

## 📁 추가된 파일
| 파일 | 역할 |
|------|------|
| `Card.java` | 카드 정보 DB 엔티티 |
| `CardRepository.java` | 카드 DB 조회 |

## 📝 수정된 파일
| 파일 | 변경 내용 |
|------|-----------|
| `GameSession.java` | cash, spxShares, currentRound, appliedCards 필드 추가 |
| `GameService.java` | 카드 선택 로직 추가 |
| `GameController.java` | POST /game/round/action 엔드포인트 추가 |
| `data.sql` | 카드 초기 데이터 삽입 (거인의 어깨 1개) |

## 🎮 게임 설계
| 항목 | 내용 |
|------|------|
| 총 라운드 | 100라운드 |
| 카드 선택 횟수 | 총 4번 |
| 카드 선택 라운드 | 1, 25, 50, 75라운드 |
| 카드 중복 선택 | 불가 |
| 카드 효과 | 선택 시점에 1번 매수 → 게임 끝까지 보유 |

## 🔍 주요 로직

### Card 엔티티
```java
@Entity
@Table(name = "card")
public class Card {
    @Id
    private Integer id;
    private String name;        // "거인의 어깨"
    private String ticker;      // "^SPX"
    private Double ratio;       // 0.3 (자산의 30%)
    private String description; // "현재 자산의 30%로 S&P500 즉시 매수"
}
```

### 카드 초기 데이터 (data.sql)
```sql
INSERT INTO card (id, name, ticker, ratio, description)
VALUES (1, '거인의 어깨', '^SPX', 0.3, '현재 자산의 30%로 S&P500 즉시 매수')
ON CONFLICT (id) DO UPDATE SET
    name = EXCLUDED.name,
    ticker = EXCLUDED.ticker,
    ratio = EXCLUDED.ratio,
    description = EXCLUDED.description;
```

### 카드 선택 시 자산 계산
```java
// 카드 선택 시점에 딱 1번 매수
double buyAmount = session.getCash() * card.getRatio(); // 자산 × 30%
double newShares = session.getSpxShares() + (buyAmount / currentClose);
long newCash = (long)(session.getCash() - buyAmount);

// 매 라운드 자산 계산
roundAsset = 현금(고정) + 보유수량(고정) × 그날 종가(변동)
returnRate = (roundAsset - initialAsset) / initialAsset × 100
```

### rounds 범위
```java
1 라운드 카드 선택  → rounds = [1~24라운드]
25 라운드 카드 선택 → rounds = [25~49라운드]
50 라운드 카드 선택 → rounds = [50~74라운드]
75 라운드 카드 선택 → rounds = [75~100라운드]
```

## 📡 API 명세

### POST /game/round/action

**Request**
```json
{
  "sessionId": "a3f9b2c1",
  "round": 1,
  "cardId": 1
}
```

**Response**
```json
{
  "success": true,
  "data": {
    "selectedCard": "거인의 어깨",
    "nextEventRound": 25,
    "rounds": [
      {
        "round": 1,
        "date": "2008-09-02",
        "priceData": [
          {
            "ticker": "^SPX",
            "open": 1287.83,
            "close": 1277.58,
            "high": 1303.04,
            "low": 1272.2,
            "changeRate": 0.0
          }
        ],
        "roundAsset": 10000000,
        "returnRate": 0.0
      },
      {
        "round": 24,
        "date": "2008-10-03",
        "priceData": [
          {
            "ticker": "^SPX",
            "open": 1115.16,
            "close": 1099.23,
            "high": 1153.82,
            "low": 1098.14,
            "changeRate": -1.35
          }
        ],
        "roundAsset": 9581200,
        "returnRate": -4.19
      }
    ]
  },
  "message": "OK"
}
```

## 📊 구현된 카드 목록
| ID | 카드명 | 종목 | 비율 | 설명 |
|----|--------|------|------|------|
| 1 | 거인의 어깨 | ^SPX | 30% | 현재 자산의 30%로 S&P500 즉시 매수 |

## ✅ 테스트 결과
| 케이스 | 결과 |
|--------|------|
| POST /game/round/action (정상) | ✅ 1~24라운드 데이터 정상 반환 |
| roundAsset, returnRate 계산 | ✅ 정상 |
| nextEventRound 계산 | ✅ 25 정상 반환 |
| 중복 카드 선택 | ✅ 예외 처리 확인 |
| 존재하지 않는 세션 | ✅ 예외 처리 확인 |

## ⚠️ 현재 제한사항
- 카드 1개만 구현 (거인의 어깨)
- 추후 이슈로 카드 추가 예정

## 🔗 연관된 이슈
close #11