### PR TITLE
[Feature] Card 엔티티 구조 개선 및 카드 5종 데이터 추가

### DIFF
--- a/backend/src/main/java/com/capstone/survival/entity/Card.java
+++ b/backend/src/main/java/com/capstone/survival/entity/Card.java
@@ -17,4 +17,21 @@ public class Card {
     private String ticker;     // "^SPX"
     private Double ratio;      // 0.3 (자산의 30%)
     private String description; // "현재 자산의 30%로 S&P500 즉시 매수"
+
+    // ↓ 새로 추가
+    private String type;
+    // BUY_ONCE         → 즉시 1회 매수
+    // BUY_SPLIT        → 매 라운드 분할 매수
+    // BUY_ON_CONDITION → 조건 충족 시 매수
+
+    private String condition;
+    // null             → 조건 없음
+    // "SPX_CHANGE <= -3" → SPX 등락률 -3% 이하
+    // "SPX_CHANGE <= -5" → SPX 등락률 -5% 이하
+    // "NDX_CHANGE >= 2"  → NDX 등락률 +2% 이상
+    // "NDX_CHANGE <= -4" → NDX 등락률 -4% 이하
+
+    private Integer maxTrigger;
+    // null → 무제한
+    // 3    → 최대 3회
 }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -13,11 +13,20 @@ ON CONFLICT (id) DO UPDATE SET
     start_date = EXCLUDED.start_date,
     end_date = EXCLUDED.end_date;
 
-INSERT INTO card (id, name, ticker, ratio, description)
+-- 기존 거인의 어깨 업데이트 (type, condition, max_trigger 반영)
+INSERT INTO card (id, name, ticker, ratio, description, type, condition, max_trigger)
 VALUES
-    (1, '거인의 어깨', '^SPX', 0.3, '현재 자산의 30%로 S&P500 즉시 매수')
+    (1, '거인의 어깨',    '^SPX',   0.30, '현재 자산의 30%로 S&P500 즉시 매수',              'BUY_ONCE',         null,              null),
+    (2, '황금 적립',      'XAUUSD', 0.05, '매 라운드마다 자산의 5%씩 금 매수',               'BUY_SPLIT',        null,              null),
+    (3, '공포탐욕',       '^SPX',   0.20, 'S&P500이 -3% 이하 하락 시 자산의 20% 매수',       'BUY_ON_CONDITION', 'SPX_CHANGE <= -3', null),
+    (4, '금 피난처',      'XAUUSD', 0.15, 'S&P500이 -5% 이하 하락 시 자산의 15% 금 매수',   'BUY_ON_CONDITION', 'SPX_CHANGE <= -5', null),
+    (5, '기술의 파도',    '^NDX',   0.10, '나스닥이 +2% 이상 상승 시 자산의 10% 매수',       'BUY_ON_CONDITION', 'NDX_CHANGE >= 2',  null),
+    (6, '낙폭과대 사냥',  '^NDX',   0.25, '나스닥이 -4% 이하 하락 시 자산의 25% 매수 (3회)', 'BUY_ON_CONDITION', 'NDX_CHANGE <= -4', 3)
     ON CONFLICT (id) DO UPDATE SET
-    name = EXCLUDED.name,
-                            ticker = EXCLUDED.ticker,
-                            ratio = EXCLUDED.ratio,
-                            description = EXCLUDED.description;
+    name        = EXCLUDED.name,
+                            ticker      = EXCLUDED.ticker,
+                            ratio       = EXCLUDED.ratio,
+                            description = EXCLUDED.description,
+                            type        = EXCLUDED.type,
+                            condition   = EXCLUDED.condition,
+                            max_trigger = EXCLUDED.max_trigger;


### PR DESCRIPTION
## #️⃣연관된 이슈> #13

## 📝작업 내용> 
카드 타입별 로직 구현을 위해 Card 엔티티에
type, condition, maxTrigger 필드를 추가하고
신규 카드 5종 초기 데이터를 삽입했습니다.

## 📁 수정된 파일
| 파일 | 변경 내용 |
|------|-----------|
| `Card.java` | type, condition, maxTrigger 필드 추가 |
| `data.sql` | 카드 6종 데이터 삽입 (거인의 어깨 업데이트 + 신규 5종 추가) |

## 🔍 주요 변경 내용

### Card 엔티티 필드 추가
```java
private String type;
// BUY_ONCE         → 즉시 1회 매수
// BUY_SPLIT        → 매 라운드 분할 매수
// BUY_ON_CONDITION → 조건 충족 시 매수

private String condition;
// null               → 조건 없음
// "SPX_CHANGE <= -3" → SPX 등락률 -3% 이하
// "SPX_CHANGE <= -5" → SPX 등락률 -5% 이하
// "NDX_CHANGE >= 2"  → NDX 등락률 +2% 이상
// "NDX_CHANGE <= -4" → NDX 등락률 -4% 이하

private Integer maxTrigger;
// null → 무제한
// 3    → 최대 3회
```

### 카드 초기 데이터 (data.sql)
```sql
INSERT INTO card (id, name, ticker, ratio, description, type, condition, max_trigger)
VALUES
(1, '거인의 어깨',   '^SPX',   0.30, '현재 자산의 30%로 S&P500 즉시 매수',            'BUY_ONCE',         null,               null),
(2, '황금 적립',     'XAUUSD', 0.05, '매 라운드마다 자산의 5%씩 금 매수',             'BUY_SPLIT',        null,               null),
(3, '공포탐욕',      '^SPX',   0.20, 'S&P500이 -3% 이하 하락 시 자산의 20% 매수',     'BUY_ON_CONDITION', 'SPX_CHANGE <= -3', null),
(4, '금 피난처',     'XAUUSD', 0.15, 'S&P500이 -5% 이하 하락 시 자산의 15% 금 매수', 'BUY_ON_CONDITION', 'SPX_CHANGE <= -5', null),
(5, '기술의 파도',   '^NDX',   0.10, '나스닥이 +2% 이상 상승 시 자산의 10% 매수',     'BUY_ON_CONDITION', 'NDX_CHANGE >= 2',  null),
(6, '낙폭과대 사냥', '^NDX',   0.25, '나스닥이 -4% 이하 하락 시 자산의 25% 매수',     'BUY_ON_CONDITION', 'NDX_CHANGE <= -4', 3)
ON CONFLICT (id) DO UPDATE SET ...
```

## 📊 카드 6종 전체 목록
| ID | 이름 | 종목 | 타입 | 조건 | 최대발동 |
|----|------|------|------|------|----------|
| 1 | 거인의 어깨 | ^SPX | BUY_ONCE | 없음 | 1회 |
| 2 | 황금 적립 | XAUUSD | BUY_SPLIT | 없음 | 무제한 |
| 3 | 공포탐욕 | ^SPX | BUY_ON_CONDITION | SPX <= -3% | 무제한 |
| 4 | 금 피난처 | XAUUSD | BUY_ON_CONDITION | SPX <= -5% | 무제한 |
| 5 | 기술의 파도 | ^NDX | BUY_ON_CONDITION | NDX >= +2% | 무제한 |
| 6 | 낙폭과대 사냥 | ^NDX | BUY_ON_CONDITION | NDX <= -4% | 3회 |

## ✅ 테스트 결과
| 케이스 | 결과 |
|--------|------|
| DB 카드 6종 삽입 확인 | ✅ 6 rows 정상 확인 |
| 서버 재시작 후 데이터 유지 | ✅ ON CONFLICT DO UPDATE 적용 |

## 🔗 연관된 이슈
close #13