### PR TITLE
[Feature] 카드 타입별 계산 로직 구현

### DIFF
--- a/backend/src/main/java/com/capstone/survival/entity/GameSession.java
+++ b/backend/src/main/java/com/capstone/survival/entity/GameSession.java
@@ -22,38 +22,53 @@ public class GameSession {
     private Long initialAsset;
     private String status; // PLAYING, FINISHED
     private String gameStartDate;
-    // 기존 필드들 아래에 추가
-    private Long cash;              // 현재 현금
-    private Double spxShares;       // 보유 SPX 수량
-    private Integer currentRound;   // 현재 라운드
-    private String appliedCards;    // 적용된 카드 목록 "1,2"
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    public GameSession(String sessionId, Integer scenarioId, String scenarioTitle,
-                       String ticker, String gameStartDate) {
+    // 기존 필드들 아래에 추가
+    private Long cash;              // 현재 현금
+    private Double spxShares;       // 보유 SPX 수량
+    private Double ndxShares;      // ← 새로 추가
+    private Double xauusdShares;   // ← 새로 추가
+    private Integer currentRound;   // 현재 라운드
+    private String appliedCards;    // 적용된 카드 목록 "1,2"
+
+    @Column(name = "trigger_count")
+    private String triggerCount;
+    // ↑ 카드별 발동 횟수 저장 "6:2" → 카드6번이 2회 발동됨
+
+    public GameSession(String sessionId, Integer scenarioId,
+                       String scenarioTitle, String ticker,
+                       String gameStartDate) {
         this.sessionId = sessionId;
         this.scenarioId = scenarioId;
         this.scenarioTitle = scenarioTitle;
         this.ticker = ticker;
-        this.totalRounds = 10;
+        this.totalRounds = 100;
         this.initialAsset = 10_000_000L;
         this.status = "PLAYING";
         this.gameStartDate = gameStartDate;
         this.createdAt = LocalDateTime.now();
-        this.cash = 10_000_000L;  // 초기 현금 = 초기 자산
+        this.cash = 10_000_000L;
         this.spxShares = 0.0;
+        this.ndxShares = 0.0;
+        this.xauusdShares = 0.0;
         this.currentRound = 1;
         this.appliedCards = "";
+        this.triggerCount = "";
     }
 
     // 상태 업데이트 메서드 추가
-    public void update(Long cash, Double spxShares,
-                       Integer currentRound, String appliedCards) {
+    public void update(Long cash, Double spxShares, Double ndxShares,
+                       Double xauusdShares, Integer currentRound,
+                       String appliedCards, String triggerCount) {
         this.cash = cash;
         this.spxShares = spxShares;
+        this.ndxShares = ndxShares;
+        this.xauusdShares = xauusdShares;
         this.currentRound = currentRound;
         this.appliedCards = appliedCards;
+        this.triggerCount = triggerCount;
     }
 }

--- a/backend/src/main/java/com/capstone/survival/service/GameService.java
+++ b/backend/src/main/java/com/capstone/survival/service/GameService.java
@@ -24,19 +24,17 @@ public class GameService {
     private final StockPriceRepository stockPriceRepository;
     private final CardRepository cardRepository;
 
-    // 카드 선택 라운드 고정
     private static final List<Integer> CARD_SELECT_ROUNDS = List.of(1, 25, 50, 75);
+    private static final List<Integer> ALL_CARD_IDS = List.of(1, 2, 3, 4, 5, 6);
 
     // =============================================
     // 게임 시작
     // =============================================
     public Map<String, Object> startGame(Integer scenarioId) {
 
-        // 1. 시나리오 조회
         Scenario scenario = scenarioRepository.findById(scenarioId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 시나리오입니다"));
 
-        // 2. 주가 데이터 조회
         List<StockPrice> priceList = stockPriceRepository
                 .findByTickerAndTradeDateBetweenOrderByTradeDate(
                         scenario.getTicker(),
@@ -48,40 +46,35 @@ public class GameService {
             throw new IllegalStateException("주가 데이터가 부족합니다");
         }
 
-        // 3. 세션 생성
         String sessionId = UUID.randomUUID().toString().substring(0, 8);
         GameSession session = new GameSession(
-                sessionId,
-                scenarioId,
-                scenario.getTitle(),
-                scenario.getTicker(),
-                priceList.get(0).getTradeDate().toString()
+                sessionId, scenarioId, scenario.getTitle(),
+                scenario.getTicker(), priceList.get(0).getTradeDate().toString()
         );
         sessionRepository.save(session);
 
-        // 4. 1라운드 데이터만 반환 (카드 선택해야 하니까)
+        // 1라운드 데이터
         StockPrice first = priceList.get(0);
-
         Map<String, Object> priceData = new LinkedHashMap<>();
         priceData.put("ticker", first.getTicker());
         priceData.put("open", first.getOpen());
         priceData.put("close", first.getClose());
         priceData.put("high", first.getHigh());
         priceData.put("low", first.getLow());
-        priceData.put("changeRate", 0.0); // 첫 라운드는 비교 대상 없음
+        priceData.put("changeRate", 0.0);
 
         Map<String, Object> firstRound = new LinkedHashMap<>();
         firstRound.put("round", 1);
         firstRound.put("date", first.getTradeDate().toString());
         firstRound.put("priceData", List.of(priceData));
 
-        // 5. 응답 반환
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("sessionId", sessionId);
         response.put("scenarioTitle", scenario.getTitle());
         response.put("totalRounds", 100);
         response.put("initialAsset", 10_000_000L);
         response.put("cardSelectRounds", CARD_SELECT_ROUNDS);
+        response.put("firstCardOptions", getRandomCards(new ArrayList<>()));
         response.put("rounds", List.of(firstRound));
 
         return response;
@@ -93,52 +86,78 @@ public class GameService {
     public Map<String, Object> selectCard(
             String sessionId, Integer round, Integer cardId) {
 
-        // 1. 세션 조회
         GameSession session = sessionRepository.findById(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다"));
 
-        // 2. 카드 조회
         Card card = cardRepository.findById(cardId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카드입니다"));
 
-        // 3. 중복 카드 체크
+        // 중복 카드 체크
         List<Integer> appliedCardIds = getAppliedCardIds(session);
         if (appliedCardIds.contains(cardId)) {
             throw new IllegalArgumentException("이미 선택한 카드입니다");
         }
 
-        // 4. 카드 효과 적용 (매수)
-        double currentClose = getPriceAtRound(session, round);
-        double buyAmount = session.getCash() * card.getRatio();
-        double newShares = session.getSpxShares() + (buyAmount / currentClose);
-        long newCash = (long)(session.getCash() - buyAmount);
-
-        // 5. 적용된 카드 목록 업데이트
+        // 적용 카드 목록 업데이트
         appliedCardIds.add(cardId);
         String newAppliedCards = appliedCardIds.stream()
                 .map(String::valueOf)
                 .collect(Collectors.joining(","));
 
-        // 6. 다음 증강 라운드 계산
+        // BUY_ONCE 즉시 매수 처리
+        double spxShares = session.getSpxShares();
+        double ndxShares = session.getNdxShares();
+        double xauusdShares = session.getXauusdShares();
+        long cash = session.getCash();
+
+        if ("BUY_ONCE".equals(card.getType())) {
+            double currentClose = getPriceAtRound(session, round, card.getTicker());
+            double buyAmount = cash * card.getRatio();
+            cash -= (long) buyAmount;
+            double newShares = buyAmount / currentClose;
+            if ("^SPX".equals(card.getTicker())) spxShares += newShares;
+            else if ("^NDX".equals(card.getTicker())) ndxShares += newShares;
+            else if ("XAUUSD".equals(card.getTicker())) xauusdShares += newShares;
+        }
+
+        // 다음 증강 라운드
         Integer nextEventRound = CARD_SELECT_ROUNDS.stream()
                 .filter(r -> r > round)
                 .findFirst()
                 .orElse(null);
 
-        // 7. 현재 라운드부터 다음 증강 직전까지 계산
         int endRound = nextEventRound != null ? nextEventRound - 1 : 100;
-        List<Map<String, Object>> rounds = calculateRounds(
-                session, round, endRound, newCash, newShares
+
+        // 라운드 계산
+        Map<String, Object> calcResult = calculateRounds(
+                session, round, endRound,
+                cash, spxShares, ndxShares, xauusdShares,
+                appliedCardIds, session.getTriggerCount()
         );
 
-        // 8. 세션 업데이트
-        session.update(newCash, newShares, endRound + 1, newAppliedCards);
+        List<Map<String, Object>> rounds = (List<Map<String, Object>>) calcResult.get("rounds");
+        long finalCash = (long) calcResult.get("finalCash");
+        double finalSpx = (double) calcResult.get("finalSpx");
+        double finalNdx = (double) calcResult.get("finalNdx");
+        double finalXauusd = (double) calcResult.get("finalXauusd");
+        String finalTriggerCount = (String) calcResult.get("triggerCount");
+
+        // 세션 업데이트
+        session.update(
+                finalCash, finalSpx, finalNdx, finalXauusd,
+                endRound + 1, newAppliedCards, finalTriggerCount
+        );
         sessionRepository.save(session);
 
-        // 9. 응답 반환
+        // 다음 카드 옵션
+        List<Integer> nextCardOptions = nextEventRound != null
+                ? getRandomCards(appliedCardIds)
+                : null;
+
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("selectedCard", card.getName());
         response.put("nextEventRound", nextEventRound);
+        response.put("nextCardOptions", nextCardOptions);
         response.put("rounds", rounds);
 
         return response;
@@ -147,73 +166,209 @@ public class GameService {
     // =============================================
     // 라운드별 자산 계산
     // =============================================
-    private List<Map<String, Object>> calculateRounds(
+    private Map<String, Object> calculateRounds(
             GameSession session, int startRound, int endRound,
-            long cash, double shares) {
+            long cash, double spxShares, double ndxShares, double xauusdShares,
+            List<Integer> appliedCardIds, String triggerCountStr) {
 
-        List<StockPrice> priceList = stockPriceRepository
-                .findByTickerAndTradeDateGreaterThanEqualOrderByTradeDate(
-                        session.getTicker(),
-                        LocalDate.parse(session.getGameStartDate())
-                );
+        // 주가 데이터 로드
+        List<StockPrice> spxList = loadPriceList(session, "^SPX");
+        List<StockPrice> ndxList = loadPriceList(session, "^NDX");
+        List<StockPrice> xauusdList = loadPriceList(session, "XAUUSD");
+
+        // 적용된 카드 목록
+        List<Card> appliedCards = cardRepository.findAllById(appliedCardIds);
+
+        // 발동 횟수 파싱
+        Map<Integer, Integer> triggerMap = parseTriggerCount(triggerCountStr);
 
         List<Map<String, Object>> rounds = new ArrayList<>();
 
         for (int i = startRound - 1; i < endRound; i++) {
-            if (i >= priceList.size()) break;
+            if (i >= spxList.size()) break;
 
-            StockPrice current = priceList.get(i);
-            StockPrice prev = i > 0 ? priceList.get(i - 1) : null;
+            StockPrice spxCurrent = spxList.get(i);
+            StockPrice spxPrev = i > 0 ? spxList.get(i - 1) : null;
+            StockPrice ndxCurrent = i < ndxList.size() ? ndxList.get(i) : null;
+            StockPrice xauusdCurrent = i < xauusdList.size() ? xauusdList.get(i) : null;
+            StockPrice ndxPrev = (i > 0 && i < ndxList.size()) ? ndxList.get(i - 1) : null;
 
             // 등락률 계산
-            double changeRate = 0.0;
-            if (prev != null && prev.getClose() > 0) {
-                changeRate = (current.getClose() - prev.getClose())
-                        / prev.getClose() * 100;
-                changeRate = Math.round(changeRate * 100.0) / 100.0;
+            double spxChangeRate = calcChangeRate(spxPrev, spxCurrent);
+            double ndxChangeRate = calcChangeRate(ndxPrev, ndxCurrent);
+
+            // 카드 발동 처리
+            // ticker별 매수 금액 합산
+            Map<String, Double> buyAmountByTicker = new LinkedHashMap<>();
+
+            for (Card card : appliedCards) {
+                if ("BUY_ONCE".equals(card.getType())) continue; // 이미 처리됨
+
+                boolean triggered = false;
+
+                if ("BUY_SPLIT".equals(card.getType())) {
+                    triggered = true;
+                } else if ("BUY_ON_CONDITION".equals(card.getType())) {
+                    triggered = checkCondition(card.getCondition(), spxChangeRate, ndxChangeRate);
+                }
+
+                if (!triggered) continue;
+
+                // maxTrigger 체크
+                if (card.getMaxTrigger() != null) {
+                    int count = triggerMap.getOrDefault(card.getId(), 0);
+                    if (count >= card.getMaxTrigger()) continue;
+                    triggerMap.put(card.getId(), count + 1);
+                }
+
+                // 매수 금액 합산 (같은 종목이면 더함)
+                double amount = cash * card.getRatio();
+                buyAmountByTicker.merge(card.getTicker(), amount, Double::sum);
+            }
+
+            // 실제 매수 실행
+            for (Map.Entry<String, Double> entry : buyAmountByTicker.entrySet()) {
+                String ticker = entry.getKey();
+                double amount = entry.getValue();
+                if (amount <= 0 || cash <= 0) continue;
+
+                amount = Math.min(amount, cash); // 현금 초과 방지
+                double price = getTickerPrice(ticker, spxCurrent, ndxCurrent, xauusdCurrent);
+                if (price <= 0) continue;
+
+                cash -= (long) amount;
+                double shares = amount / price;
+                if ("^SPX".equals(ticker)) spxShares += shares;
+                else if ("^NDX".equals(ticker)) ndxShares += shares;
+                else if ("XAUUSD".equals(ticker)) xauusdShares += shares;
             }
 
             // 자산 계산
-            long roundAsset = (long)(cash + shares * current.getClose());
-            double returnRate = (double)(roundAsset - session.getInitialAsset())
-                    / session.getInitialAsset() * 100;
-            returnRate = Math.round(returnRate * 100.0) / 100.0;
+            double spxValue = spxShares * spxCurrent.getClose();
+            double ndxValue = ndxCurrent != null ? ndxShares * ndxCurrent.getClose() : 0;
+            double xauusdValue = xauusdCurrent != null ? xauusdShares * xauusdCurrent.getClose() : 0;
+            long roundAsset = (long)(cash + spxValue + ndxValue + xauusdValue);
+            double returnRate = Math.round(
+                    (double)(roundAsset - session.getInitialAsset())
+                            / session.getInitialAsset() * 100 * 100.0) / 100.0;
 
-            // priceData
-            Map<String, Object> priceData = new LinkedHashMap<>();
-            priceData.put("ticker", current.getTicker());
-            priceData.put("open", current.getOpen());
-            priceData.put("close", current.getClose());
-            priceData.put("high", current.getHigh());
-            priceData.put("low", current.getLow());
-            priceData.put("changeRate", changeRate);
+            // priceData 구성 (보유 종목만)
+            List<Map<String, Object>> priceDataList = new ArrayList<>();
 
-            // round
+            // SPX
+            Map<String, Object> spxData = new LinkedHashMap<>();
+            spxData.put("ticker", "^SPX");
+            spxData.put("open", spxCurrent.getOpen());
+            spxData.put("close", spxCurrent.getClose());
+            spxData.put("high", spxCurrent.getHigh());
+            spxData.put("low", spxCurrent.getLow());
+            spxData.put("changeRate", spxChangeRate);
+            priceDataList.add(spxData);
+
+            // NDX (보유 중인 경우만)
+            if (ndxShares > 0 && ndxCurrent != null) {
+                Map<String, Object> ndxData = new LinkedHashMap<>();
+                ndxData.put("ticker", "^NDX");
+                ndxData.put("open", ndxCurrent.getOpen());
+                ndxData.put("close", ndxCurrent.getClose());
+                ndxData.put("high", ndxCurrent.getHigh());
+                ndxData.put("low", ndxCurrent.getLow());
+                ndxData.put("changeRate", ndxChangeRate);
+                priceDataList.add(ndxData);
+            }
+
+            // XAUUSD (보유 중인 경우만)
+            if (xauusdShares > 0 && xauusdCurrent != null) {
+                double xauusdChangeRate = calcChangeRate(
+                        i > 0 && i < xauusdList.size() ? xauusdList.get(i - 1) : null,
+                        xauusdCurrent
+                );
+                Map<String, Object> xauusdData = new LinkedHashMap<>();
+                xauusdData.put("ticker", "XAUUSD");
+                xauusdData.put("open", xauusdCurrent.getOpen());
+                xauusdData.put("close", xauusdCurrent.getClose());
+                xauusdData.put("high", xauusdCurrent.getHigh());
+                xauusdData.put("low", xauusdCurrent.getLow());
+                xauusdData.put("changeRate", xauusdChangeRate);
+                priceDataList.add(xauusdData);
+            }
+
             Map<String, Object> roundMap = new LinkedHashMap<>();
             roundMap.put("round", i + 1);
-            roundMap.put("date", current.getTradeDate().toString());
-            roundMap.put("priceData", List.of(priceData));
+            roundMap.put("date", spxCurrent.getTradeDate().toString());
+            roundMap.put("priceData", priceDataList);
             roundMap.put("roundAsset", roundAsset);
             roundMap.put("returnRate", returnRate);
-
             rounds.add(roundMap);
         }
 
-        return rounds;
+        Map<String, Object> result = new HashMap<>();
+        result.put("rounds", rounds);
+        result.put("finalCash", cash);
+        result.put("finalSpx", spxShares);
+        result.put("finalNdx", ndxShares);
+        result.put("finalXauusd", xauusdShares);
+        result.put("triggerCount", serializeTriggerCount(triggerMap));
+        return result;
     }
 
     // =============================================
     // 유틸 메서드
     // =============================================
 
-    // 특정 라운드 종가 조회
-    private double getPriceAtRound(GameSession session, int round) {
-        List<StockPrice> priceList = stockPriceRepository
+    // 조건 체크
+    private boolean checkCondition(String condition,
+                                   double spxChangeRate, double ndxChangeRate) {
+        if (condition == null) return false;
+        return switch (condition) {
+            case "SPX_CHANGE <= -3" -> spxChangeRate <= -3;
+            case "SPX_CHANGE <= -5" -> spxChangeRate <= -5;
+            case "NDX_CHANGE >= 2"  -> ndxChangeRate >= 2;
+            case "NDX_CHANGE <= -4" -> ndxChangeRate <= -4;
+            default -> false;
+        };
+    }
+
+    // 등락률 계산
+    private double calcChangeRate(StockPrice prev, StockPrice current) {
+        if (prev == null || current == null || prev.getClose() <= 0) return 0.0;
+        double rate = (current.getClose() - prev.getClose()) / prev.getClose() * 100;
+        return Math.round(rate * 100.0) / 100.0;
+    }
+
+    // ticker별 현재가 반환
+    private double getTickerPrice(String ticker,
+                                  StockPrice spx, StockPrice ndx, StockPrice xauusd) {
+        return switch (ticker) {
+            case "^SPX"   -> spx != null ? spx.getClose() : 0;
+            case "^NDX"   -> ndx != null ? ndx.getClose() : 0;
+            case "XAUUSD" -> xauusd != null ? xauusd.getClose() : 0;
+            default -> 0;
+        };
+    }
+
+    // 주가 데이터 로드
+    private List<StockPrice> loadPriceList(GameSession session, String ticker) {
+        return stockPriceRepository
                 .findByTickerAndTradeDateGreaterThanEqualOrderByTradeDate(
-                        session.getTicker(),
-                        LocalDate.parse(session.getGameStartDate())
+                        ticker, LocalDate.parse(session.getGameStartDate())
                 );
-        return priceList.get(round - 1).getClose();
+    }
+
+    // 특정 라운드 종가 조회
+    private double getPriceAtRound(GameSession session, int round, String ticker) {
+        List<StockPrice> list = loadPriceList(session, ticker);
+        if (round - 1 >= list.size()) return 0;
+        return list.get(round - 1).getClose();
+    }
+
+    // 랜덤 카드 3개 뽑기 (이미 선택한 카드 제외)
+    private List<Integer> getRandomCards(List<Integer> appliedCardIds) {
+        List<Integer> available = new ArrayList<>(ALL_CARD_IDS);
+        available.removeAll(appliedCardIds);
+        Collections.shuffle(available);
+        int count = Math.min(3, available.size());
+        return new ArrayList<>(available.subList(0, count));
     }
 
     // 적용된 카드 ID 목록 파싱
@@ -225,5 +380,25 @@ public class GameService {
         return Arrays.stream(session.getAppliedCards().split(","))
                 .map(Integer::parseInt)
                 .collect(Collectors.toList());
+    }
+
+    // 발동 횟수 파싱 "6:2,3:1" → {6: 2, 3: 1}
+    private Map<Integer, Integer> parseTriggerCount(String str) {
+        Map<Integer, Integer> map = new HashMap<>();
+        if (str == null || str.isEmpty()) return map;
+        for (String entry : str.split(",")) {
+            String[] parts = entry.split(":");
+            if (parts.length == 2) {
+                map.put(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]));
+            }
+        }
+        return map;
+    }
+
+    // 발동 횟수 직렬화 {6: 2, 3: 1} → "6:2,3:1"
+    private String serializeTriggerCount(Map<Integer, Integer> map) {
+        return map.entrySet().stream()
+                .map(e -> e.getKey() + ":" + e.getValue())
+                .collect(Collectors.joining(","));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈> #15 

## 📝작업 내용> 
Card 엔티티의 type, condition, maxTrigger를 기반으로
카드별 매수 로직을 구현했습니다.
같은 종목 카드 중복 시 합산 처리,
다른 종목 카드 각각 처리도 포함했습니다.

## 📁 수정된 파일
| 파일 | 변경 내용 |
|------|-----------|
| `GameSession.java` | ndxShares, xauusdShares, triggerCount 필드 추가 |
| `GameService.java` | 카드 타입별 계산 로직 전체 구현 |

## 🔍 주요 로직

### 카드 타입별 동작
```java
// BUY_ONCE → 카드 선택 시 즉시 1회 매수
if ("BUY_ONCE".equals(card.getType())) {
    double buyAmount = cash * card.getRatio();
    cash -= (long) buyAmount;
    spxShares += buyAmount / currentClose;
}

// BUY_SPLIT → 매 라운드 자동 매수
if ("BUY_SPLIT".equals(card.getType())) {
    triggered = true;
}

// BUY_ON_CONDITION → 조건 충족 시 매수
private boolean checkCondition(String condition,
        double spxChangeRate, double ndxChangeRate) {
    return switch (condition) {
        case "SPX_CHANGE <= -3" -> spxChangeRate <= -3;
        case "SPX_CHANGE <= -5" -> spxChangeRate <= -5;
        case "NDX_CHANGE >= 2"  -> ndxChangeRate >= 2;
        case "NDX_CHANGE <= -4" -> ndxChangeRate <= -4;
        default -> false;
    };
}
```

### maxTrigger 처리 (낙폭과대 사냥 3회 제한)
```java
if (card.getMaxTrigger() != null) {
    int count = triggerMap.getOrDefault(card.getId(), 0);
    if (count >= card.getMaxTrigger()) continue; // 제한 초과 시 스킵
    triggerMap.put(card.getId(), count + 1);
}
```

### 같은 종목 카드 합산 처리
```java
// ticker별 매수 금액 합산
Map<String, Double> buyAmountByTicker = new LinkedHashMap<>();
buyAmountByTicker.merge(card.getTicker(), amount, Double::sum);
// → 같은 ticker면 더하고, 다른 ticker면 각각 추가
```

### 자산 계산
```java
roundAsset = 현금
           + SPX 보유수량 × SPX 종가
           + NDX 보유수량 × NDX 종가
           + XAUUSD 보유수량 × XAUUSD 종가
```

### 랜덤 카드 옵션
```java
// 이미 선택한 카드 제외하고 랜덤 3개 추출
private List<Integer> getRandomCards(List<Integer> appliedCardIds) {
    List<Integer> available = new ArrayList<>(ALL_CARD_IDS);
    available.removeAll(appliedCardIds);
    Collections.shuffle(available);
    return new ArrayList<>(available.subList(0, Math.min(3, available.size())));
}
```

## 📡 API 변경사항

### POST /game/start 추가 필드
```json
{
  "cardSelectRounds": [1, 25, 50, 75],
  "firstCardOptions": [1, 3, 5]
}
```

### POST /game/round/action 추가 필드
```json
{
  "nextCardOptions": [3, 5, 2]
}
```

## 📊 카드 6종 동작 정리
| ID | 이름 | 타입 | 조건 | 최대발동 |
|----|------|------|------|----------|
| 1 | 거인의 어깨 | BUY_ONCE | 없음 | 1회 |
| 2 | 황금 적립 | BUY_SPLIT | 없음 | 무제한 |
| 3 | 공포탐욕 | BUY_ON_CONDITION | SPX <= -3% | 무제한 |
| 4 | 금 피난처 | BUY_ON_CONDITION | SPX <= -5% | 무제한 |
| 5 | 기술의 파도 | BUY_ON_CONDITION | NDX >= +2% | 무제한 |
| 6 | 낙폭과대 사냥 | BUY_ON_CONDITION | NDX <= -4% | 3회 |

## ✅ 테스트 결과
| 케이스 | 결과 |
|--------|------|
| BUY_ONCE (거인의 어깨) | ✅ 즉시 1회 매수 정상 |
| firstCardOptions 반환 | ✅ 랜덤 3개 정상 반환 |
| nextCardOptions 반환 | ✅ 선택한 카드 제외 랜덤 3개 정상 반환 |
| nextEventRound null 시 nextCardOptions null | ✅ 정상 |
| 중복 카드 선택 방지 | ✅ 예외 처리 확인 |

## 🔗 연관된 이슈
close #15 