### PR TITLE
[Feature] 게임 진행 핵심 기능 구현 - 카드 선택 / 자동재생 / 멀티차트

### DIFF
--- a/frontEnd/lib/models/action_result.dart
+++ b/frontEnd/lib/models/action_result.dart
@@ -1,23 +1,26 @@
 import 'round_data.dart';
 
-// POST /game/round/action 응답
 class ActionResult {
   final String selectedCard;
-  final List<RoundData> rounds;   // 카드 선택 시점 ~ 다음 증강 직전까지
-  final int? nextEventRound;      // 다음 증강 라운드 (없으면 null = 게임 끝까지)
+  final List<RoundData> rounds;
+  final int? nextEventRound;
+  final List<int> nextCardOptions;  // 다음 증강 카드 선택지
 
   ActionResult({
     required this.selectedCard,
     required this.rounds,
     this.nextEventRound,
+    this.nextCardOptions = const [],
   });
 
   factory ActionResult.fromJson(Map<String, dynamic> json) {
-    final List<dynamic> roundList = json['rounds'] ?? [];
+    final List<dynamic> roundList    = json['rounds']          ?? [];
+    final List<dynamic> nextCardList = json['nextCardOptions'] ?? [];
     return ActionResult(
-      selectedCard: json['selectedCard'] ?? '',
-      rounds: roundList.map((e) => RoundData.fromJson(e)).toList(),
-      nextEventRound: json['nextEventRound'],
+      selectedCard:    json['selectedCard']  ?? '',
+      nextEventRound:  json['nextEventRound'],
+      nextCardOptions: nextCardList.map((e) => e as int).toList(),
+      rounds:          roundList.map((e) => RoundData.fromJson(e)).toList(),
     );
   }
 }

--- a/frontEnd/lib/models/card_info.dart
+++ b/frontEnd/lib/models/card_info.dart
@@ -1,0 +1,73 @@
+// 카드 정보 정의
+// 서버에서 cardId를 받으면 클라에서 이 정보로 UI를 그림
+
+class CardInfo {
+  final int id;
+  final String name;
+  final String description;
+  final String emoji;
+  final String ticker;
+
+  const CardInfo({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.emoji,
+    required this.ticker,
+  });
+
+  // cardId로 카드 정보 찾기
+  static CardInfo? fromId(int id) {
+    try {
+      return all.firstWhere((c) => c.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // 전체 카드 목록
+  static const List<CardInfo> all = [
+    CardInfo(
+      id: 1,
+      name: '거인의 어깨',
+      description: '현재 자산의 30%로\nS&P500 즉시 매수',
+      emoji: '🏛️',
+      ticker: '^SPX',
+    ),
+    CardInfo(
+      id: 2,
+      name: '황금 적립',
+      description: '매 라운드\n자산의 5%씩 금 매수',
+      emoji: '🪙',
+      ticker: 'GLD',
+    ),
+    CardInfo(
+      id: 3,
+      name: '공포탐욕',
+      description: 'SPX -3% 이하 시\n자산의 20% SPX 매수',
+      emoji: '😱',
+      ticker: '^SPX',
+    ),
+    CardInfo(
+      id: 4,
+      name: '금 피난처',
+      description: 'SPX -5% 이하 시\n자산의 15% 금 매수',
+      emoji: '🛡️',
+      ticker: 'GLD',
+    ),
+    CardInfo(
+      id: 5,
+      name: '기술의 파도',
+      description: 'NDX +2% 이상 시\n자산의 10% 나스닥 매수',
+      emoji: '🌊',
+      ticker: '^NDX',
+    ),
+    CardInfo(
+      id: 6,
+      name: '낙폭과대 사냥',
+      description: 'NDX -4% 이하 시\n자산의 25% 나스닥 매수 (최대 3회)',
+      emoji: '🎯',
+      ticker: '^NDX',
+    ),
+  ];
+}

--- a/frontEnd/lib/models/game_session.dart
+++ b/frontEnd/lib/models/game_session.dart
@@ -1,11 +1,12 @@
 import 'round_data.dart';
 
-// POST /game/start 응답 전체
 class GameSession {
   final String sessionId;
   final String scenarioTitle;
   final int totalRounds;
   final double initialAsset;
+  final List<int> cardSelectRounds;
+  final List<int> firstCardOptions;  // 1라운드 카드 선택지
   final List<RoundData> rounds;
 
   GameSession({
@@ -13,30 +14,35 @@ class GameSession {
     required this.scenarioTitle,
     required this.totalRounds,
     required this.initialAsset,
+    required this.cardSelectRounds,
+    required this.firstCardOptions,
     required this.rounds,
   });
 
   factory GameSession.fromJson(Map<String, dynamic> json) {
-    final List<dynamic> roundList = json['rounds'] ?? [];
+    final List<dynamic> roundList       = json['rounds']           ?? [];
+    final List<dynamic> cardSelectList  = json['cardSelectRounds'] ?? [];
+    final List<dynamic> firstCardList   = json['firstCardOptions'] ?? [];
     return GameSession(
-      sessionId: json['sessionId'] ?? '',
-      scenarioTitle: json['scenarioTitle'] ?? '',
-      totalRounds: json['totalRounds'] ?? 0,
-      initialAsset: (json['initialAsset'] ?? 10000000).toDouble(),
-      rounds: roundList.map((e) => RoundData.fromJson(e)).toList(),
+      sessionId:        json['sessionId']       ?? '',
+      scenarioTitle:    json['scenarioTitle']   ?? '',
+      totalRounds:      json['totalRounds']     ?? 0,
+      initialAsset:     (json['initialAsset']   ?? 10000000).toDouble(),
+      cardSelectRounds: cardSelectList.map((e) => e as int).toList(),
+      firstCardOptions: firstCardList.map((e) => e as int).toList(),
+      rounds:           roundList.map((e) => RoundData.fromJson(e)).toList(),
     );
   }
 
-  // 특정 라운드 데이터 꺼내기 (0-based index)
-  // ex) getRound(0) → 1라운드
+  bool isCardSelectRound(int round) => cardSelectRounds.contains(round);
+
   RoundData? getRound(int index) {
     if (index < 0 || index >= rounds.length) return null;
     return rounds[index];
   }
 
-  // 현재 라운드까지 누적 데이터 (차트용)
-  // ex) getChartData(2) → 0,1,2라운드 데이터
   List<RoundData> getChartData(int currentIndex) {
+    if (currentIndex >= rounds.length) return rounds;
     return rounds.sublist(0, currentIndex + 1);
   }
 }

--- a/frontEnd/lib/screens/game_screen.dart
+++ b/frontEnd/lib/screens/game_screen.dart
@@ -1,14 +1,15 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import '../models/game_session.dart';
 import '../models/round_data.dart';
 import '../models/action_result.dart';
+import '../models/card_info.dart';
 import '../services/game_service.dart';
 import '../services/mock_data.dart';
 import '../widgets/stock_chart.dart';
 
 class GameScreen extends StatefulWidget {
   final GameSession session;
-
   const GameScreen({super.key, required this.session});
 
   @override
@@ -21,28 +22,174 @@ class _GameScreenState extends State<GameScreen> {
   late GameSession _session;
   int _currentRoundIndex = 0;
 
-  // 카드 선택 완료 여부
   bool _cardSelected = false;
-
-  // 카드 선택 로딩
   bool _isSubmitting = false;
+  bool _isAutoPlaying = false;
 
-  RoundData get _currentRound => _session.rounds[_currentRoundIndex];
-  List<RoundData> get _chartData => _session.getChartData(_currentRoundIndex);
-  String get _ticker => _currentRound.priceData.isNotEmpty
-      ? _currentRound.priceData[0].ticker
-      : '';
+  // 현재 표시할 카드 선택지
+  List<int> _currentCardOptions = [];
 
-  // 1라운드에 카드가 나와야 하는지
-  bool get _showCard => _currentRoundIndex == 0 && !_cardSelected;
+  Timer? _autoTimer;
+
+  RoundData get _currentRound {
+    final index = _currentRoundIndex.clamp(0, _session.rounds.length - 1);
+    return _session.rounds[index];
+  }
+
+  List<RoundData> get _chartData => _session.getChartData(
+    _currentRoundIndex.clamp(0, _session.rounds.length - 1),
+  );
+
+  // 현재 라운드 번호 (1-based)
+  int get _currentRound1 => _currentRoundIndex + 1;
+
+  bool get _showCard {
+    if (_cardSelected) return false;
+    // cardSelectRounds가 있으면 그 기준으로, 없으면 1라운드에 표시
+    if (_session.cardSelectRounds.isNotEmpty) {
+      return _session.isCardSelectRound(_currentRound1);
+    }
+    return _currentRound1 == 1;
+  }
+
+  // 카드 선택 전엔 종료 버튼 안 보임
+  // 다음 라운드가 카드 선택 라운드면 마지막 아님
+  bool get _isLastRound {
+    if (!_cardSelected) return false;
+    final nextRound = _currentRoundIndex + 2;
+    if (_session.isCardSelectRound(nextRound)) return false;
+    return _currentRoundIndex >= _session.rounds.length - 1;
+  }
 
   @override
   void initState() {
     super.initState();
     _session = widget.session;
+    _currentCardOptions = _session.firstCardOptions;
   }
 
+  @override
+  void dispose() {
+    _autoTimer?.cancel();
+    super.dispose();
+  }
+
+  // ── 자동 진행 ──────────────────────────────
+  void _startAutoPlay() {
+    setState(() => _isAutoPlaying = true);
+    _autoTimer = Timer.periodic(const Duration(milliseconds: 100), (_) {
+      if (!mounted) return;
+      final nextRound = _currentRoundIndex + 2;
+      final willHitCard = _session.isCardSelectRound(nextRound);
+
+      if (_isLastRound || willHitCard) {
+        _stopAutoPlay();
+        if (!_isLastRound) {
+          setState(() {
+            _currentRoundIndex++;
+            _cardSelected = false;
+          });
+        }
+      } else {
+        setState(() => _currentRoundIndex++);
+      }
+    });
+  }
+
+  void _stopAutoPlay() {
+    _autoTimer?.cancel();
+    _autoTimer = null;
+    if (mounted) setState(() => _isAutoPlaying = false);
+  }
+
+  // ── 다음 라운드 (수동) ──────────────────────
+  void _nextRound() {
+    if (_isLastRound) return;
+    final nextRound = _currentRoundIndex + 2;
+    setState(() {
+      _currentRoundIndex++;
+      if (_session.isCardSelectRound(nextRound)) {
+        _cardSelected = false;
+      }
+    });
+  }
+
+  // ── 카드 선택 (실제 API) ────────────────────
+  Future<void> _onCardSelected(int cardId) async {
+    setState(() => _isSubmitting = true);
+    try {
+      final result = await _gameService.submitAction(
+        sessionId: _session.sessionId,
+        round: _currentRound1,  // 1-based 라운드 번호
+        cardId: cardId,
+      );
+      _applyActionResult(result);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(e.toString()),
+        backgroundColor: Colors.red[700],
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+      ));
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  // ── 카드 선택 (Mock) ────────────────────────
+  void _onMockCardSelected(int cardId) {
+    final mockData = MockData.getActionResult(_currentRoundIndex);
+    final result = ActionResult.fromJson(
+      mockData['data'] as Map<String, dynamic>,
+    );
+    _applyActionResult(result);
+  }
+
+  // ── ActionResult 반영 ───────────────────────
+  void _applyActionResult(ActionResult result) {
+    // 디버그 확인용
+    print('=== ActionResult ===');
+    print('nextEventRound: ${result.nextEventRound}');
+    print('nextCardOptions: ${result.nextCardOptions}');
+    print('rounds count: ${result.rounds.length}');
+    if (result.rounds.isNotEmpty) {
+      print('rounds: ${result.rounds.first.round} ~ ${result.rounds.last.round}');
+    }
+    // 기존 rounds에 새 rounds 덮어쓰기
+    // 서버가 준 rounds를 index 기준으로 교체
+    // 기존보다 크면 늘려서 추가
+    final updatedRounds = List<RoundData>.from(_session.rounds);
+    for (final newRound in result.rounds) {
+      final index = newRound.round - 1;
+      if (index < updatedRounds.length) {
+        updatedRounds[index] = newRound;         // 기존 자리 교체
+      } else {
+        // 기존 리스트보다 크면 빈칸 채우며 추가
+        while (updatedRounds.length < index) {
+          updatedRounds.add(updatedRounds.last);
+        }
+        updatedRounds.add(newRound);
+      }
+    }
+    setState(() {
+      _session = GameSession(
+        sessionId:        _session.sessionId,
+        scenarioTitle:    _session.scenarioTitle,
+        totalRounds:      _session.totalRounds,
+        initialAsset:     _session.initialAsset,
+        cardSelectRounds: _session.cardSelectRounds,
+        firstCardOptions: _session.firstCardOptions,
+        rounds:           updatedRounds,
+      );
+      _cardSelected = true;
+      _currentCardOptions = result.nextCardOptions;
+    });
+  }
+
+  // ── Mock 세션 초기화 ────────────────────────
   void _loadMockSession() {
+    _stopAutoPlay();
     final mockSession = GameSession.fromJson(
       MockData.gameSession['data'] as Map<String, dynamic>,
     );
@@ -50,73 +197,17 @@ class _GameScreenState extends State<GameScreen> {
       _session = mockSession;
       _currentRoundIndex = 0;
       _cardSelected = false;
+      _currentCardOptions = mockSession.firstCardOptions;
     });
   }
 
-  // 카드 선택 → POST /game/round/action
-  Future<void> _onCardSelected(int cardId) async {
-    setState(() => _isSubmitting = true);
-
-    try {
-      final result = await _gameService.submitAction(
-        sessionId: _session.sessionId,
-        round: _currentRound.round,
-        cardId: cardId,
-      );
-      _applyActionResult(result);
-    } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(e.toString()),
-          backgroundColor: Colors.red[700],
-          behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-        ),
-      );
-    } finally {
-      if (mounted) setState(() => _isSubmitting = false);
-    }
-  }
-
-  // 임시 데이터로 카드 선택 테스트
-  void _onMockCardSelected() {
-    final result = ActionResult.fromJson(
-      MockData.actionResult['data'] as Map<String, dynamic>,
-    );
-    _applyActionResult(result);
-  }
-
-  // 카드 선택 결과를 세션 rounds에 반영
-  void _applyActionResult(ActionResult result) {
-    // 기존 rounds에서 actionResult의 rounds로 교체
-    final updatedRounds = List<RoundData>.from(_session.rounds);
-    for (final newRound in result.rounds) {
-      final index = newRound.round - 1; // round는 1-based
-      if (index >= 0 && index < updatedRounds.length) {
-        updatedRounds[index] = newRound;
-      }
-    }
-
-    setState(() {
-      _session = GameSession(
-        sessionId: _session.sessionId,
-        scenarioTitle: _session.scenarioTitle,
-        totalRounds: _session.totalRounds,
-        initialAsset: _session.initialAsset,
-        rounds: updatedRounds,
-      );
-      _cardSelected = true;
-    });
-  }
-
+  // ── Build ───────────────────────────────────
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: const Color(0xFFFAF9F5),
       body: SafeArea(
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildHeader(),
             Padding(
@@ -125,19 +216,16 @@ class _GameScreenState extends State<GameScreen> {
             ),
             Expanded(
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+                padding: const EdgeInsets.fromLTRB(20, 10, 20, 20),
                 child: Column(
                   children: [
                     _buildChartArea(),
-                    const SizedBox(height: 12),
+                    const SizedBox(height: 10),
                     _buildRoundInfo(),
-                    const SizedBox(height: 12),
-
-                    // 1라운드 + 카드 미선택 → 카드 UI
-                    // 그 외 → 다음 라운드 버튼
+                    const SizedBox(height: 10),
                     _showCard
                         ? _buildCardSelector()
-                        : _buildNextRoundButton(),
+                        : _buildControls(),
                   ],
                 ),
               ),
@@ -148,6 +236,38 @@ class _GameScreenState extends State<GameScreen> {
     );
   }
 
+  // ── 헤더 ────────────────────────────────────
+  Widget _buildHeader() {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 10),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: () { _stopAutoPlay(); Navigator.pop(context); },
+            child: const Icon(Icons.arrow_back_ios_rounded, size: 18, color: Color(0xFF111111)),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(_session.scenarioTitle,
+              style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w700, color: Color(0xFF111111))),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: const Color(0xFFEEEDFE),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Text(
+              '$_currentRound1 / ${_session.totalRounds}',
+              style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: Color(0xFF3C3489)),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── 개발용 버튼 ─────────────────────────────
   Widget _buildMockButton() {
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
@@ -159,149 +279,120 @@ class _GameScreenState extends State<GameScreen> {
       ),
       child: Row(
         children: [
-          const Text(
-            '개발용',
-            style: TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-              color: Color(0xFF856404),
-            ),
-          ),
+          const Text('개발용', style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: Color(0xFF856404))),
           const SizedBox(width: 8),
-          _devButton('세션 초기화', _loadMockSession),
+          Expanded(child: _devBtn('세션 초기화', _loadMockSession)),
           const SizedBox(width: 6),
-          _devButton('임시 카드선택', _onMockCardSelected),
+          Expanded(child: _devBtn(
+            '임시 카드선택',
+            !_cardSelected
+                ? () => _onMockCardSelected(_currentCardOptions.isNotEmpty ? _currentCardOptions[0] : 1)
+                : null,
+          )),
         ],
       ),
     );
   }
 
-  Widget _devButton(String label, VoidCallback onTap) {
-    return Expanded(
-      child: GestureDetector(
-        onTap: onTap,
-        child: Container(
-          padding: const EdgeInsets.symmetric(vertical: 6),
-          decoration: BoxDecoration(
-            color: const Color(0xFF111111),
-            borderRadius: BorderRadius.circular(7),
-          ),
-          child: Text(
-            label,
-            textAlign: TextAlign.center,
-            style: const TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-              color: Colors.white,
-            ),
-          ),
+  Widget _devBtn(String label, VoidCallback? onTap) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        decoration: BoxDecoration(
+          color: onTap == null ? const Color(0xFFEEEEEE) : const Color(0xFF111111),
+          borderRadius: BorderRadius.circular(7),
         ),
+        child: Text(label,
+          textAlign: TextAlign.center,
+          style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600,
+            color: onTap == null ? const Color(0xFFAAAAAA) : Colors.white)),
       ),
     );
   }
 
-  Widget _buildHeader() {
-    return Container(
-      padding: const EdgeInsets.fromLTRB(20, 20, 20, 12),
-      child: Row(
-        children: [
-          GestureDetector(
-            onTap: () => Navigator.pop(context),
-            child: const Icon(
-              Icons.arrow_back_ios_rounded,
-              size: 18,
-              color: Color(0xFF111111),
-            ),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Text(
-              _session.scenarioTitle,
-              style: const TextStyle(
-                fontSize: 17,
-                fontWeight: FontWeight.w700,
-                color: Color(0xFF111111),
-              ),
-            ),
-          ),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-            decoration: BoxDecoration(
-              color: const Color(0xFFEEEDFE),
-              borderRadius: BorderRadius.circular(20),
-            ),
-            child: Text(
-              '${_currentRoundIndex + 1} / ${_session.totalRounds}',
-              style: const TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-                color: Color(0xFF3C3489),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
+  // ── 차트 영역 ───────────────────────────────
   Widget _buildChartArea() {
     return Expanded(
       flex: 7,
       child: Container(
         width: double.infinity,
-        padding: const EdgeInsets.fromLTRB(8, 16, 16, 8),
+        padding: const EdgeInsets.fromLTRB(8, 12, 12, 8),
         decoration: BoxDecoration(
           color: Colors.white,
           borderRadius: BorderRadius.circular(16),
           border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(left: 8, bottom: 12),
-              child: Row(
-                children: [
-                  Text(
-                    _ticker,
-                    style: const TextStyle(
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                      color: Color(0xFF6B7684),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    _currentRound.priceData.isNotEmpty
-                        ? _currentRound.priceData[0].close.toStringAsFixed(2)
-                        : '-',
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
-                      color: Color(0xFF111111),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Expanded(
-              child: StockChart(
-                rounds: _chartData,
-                ticker: _ticker,
-              ),
-            ),
-          ],
-        ),
+        child: StockChart(rounds: _chartData),
       ),
     );
   }
 
+  // ── 라운드 정보 ─────────────────────────────
   Widget _buildRoundInfo() {
     final round = _currentRound;
     final asset = round.roundAsset ?? _session.initialAsset;
     final returnRate = round.returnRate;
-    final isPositiveReturn = (returnRate ?? 0) >= 0;
+    final isPos = (returnRate ?? 0) >= 0;
 
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(round.date, style: const TextStyle(fontSize: 12, color: Color(0xFF6B7684))),
+                const SizedBox(height: 4),
+                Row(
+                  children: round.priceData.map((price) => Padding(
+                    padding: const EdgeInsets.only(right: 12),
+                    child: Row(
+                      children: [
+                        Container(width: 8, height: 8, decoration: BoxDecoration(
+                          color: tickerColor(price.ticker), shape: BoxShape.circle,
+                        )),
+                        const SizedBox(width: 4),
+                        Text(
+                          '${price.ticker} ${price.changeRate >= 0 ? '+' : ''}${price.changeRate.toStringAsFixed(2)}%',
+                          style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600,
+                            color: price.isPositive ? const Color(0xFFE03131) : const Color(0xFF1971C2)),
+                        ),
+                      ],
+                    ),
+                  )).toList(),
+                ),
+              ],
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              const Text('총자산', style: TextStyle(fontSize: 11, color: Color(0xFF6B7684))),
+              Text('₩${_formatNumber(asset)}',
+                style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Color(0xFF111111))),
+              if (returnRate != null)
+                Text(
+                  '${isPos ? '+' : ''}${returnRate.toStringAsFixed(2)}%',
+                  style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600,
+                    color: isPos ? const Color(0xFFE03131) : const Color(0xFF1971C2)),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── 카드 선택 UI ────────────────────────────
+  Widget _buildCardSelector() {
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(14),
@@ -310,214 +401,98 @@ class _GameScreenState extends State<GameScreen> {
         borderRadius: BorderRadius.circular(16),
         border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
       ),
-      child: Row(
-        children: [
-          // 날짜 + 종목 등락률
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  round.date,
-                  style: const TextStyle(
-                    fontSize: 12,
-                    color: Color(0xFF6B7684),
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-                const SizedBox(height: 6),
-                Row(
-                  children: round.priceData.map((price) {
-                    final isPositive = price.isPositive;
-                    return Padding(
-                      padding: const EdgeInsets.only(right: 16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            price.ticker,
-                            style: const TextStyle(
-                              fontSize: 11,
-                              color: Color(0xFF6B7684),
-                            ),
-                          ),
-                          Text(
-                            '${isPositive ? '+' : ''}${price.changeRate.toStringAsFixed(2)}%',
-                            style: TextStyle(
-                              fontSize: 13,
-                              fontWeight: FontWeight.w600,
-                              color: isPositive
-                                  ? const Color(0xFFE03131)
-                                  : const Color(0xFF1971C2),
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                  }).toList(),
-                ),
-              ],
-            ),
-          ),
-
-          // 총자산 + 수익률
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              const Text(
-                '총자산',
-                style: TextStyle(
-                  fontSize: 11,
-                  color: Color(0xFF6B7684),
-                ),
-              ),
-              const SizedBox(height: 2),
-              Text(
-                '₩${_formatNumber(asset)}',
-                style: const TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w700,
-                  color: Color(0xFF111111),
-                ),
-              ),
-              if (returnRate != null) ...[
-                const SizedBox(height: 2),
-                Text(
-                  '${isPositiveReturn ? '+' : ''}${returnRate.toStringAsFixed(2)}%',
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                    color: isPositiveReturn
-                        ? const Color(0xFFE03131)
-                        : const Color(0xFF1971C2),
-                  ),
-                ),
-              ],
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-
-  // 1라운드 카드 선택 UI
-  Widget _buildCardSelector() {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            '전략 카드를 선택하세요',
-            style: TextStyle(
-              fontSize: 13,
-              fontWeight: FontWeight.w600,
-              color: Color(0xFF6B7684),
-            ),
-          ),
+          const Text('전략 카드를 선택하세요',
+            style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: Color(0xFF6B7684))),
           const SizedBox(height: 10),
-
-          // 거인의 어깨 카드
-          GestureDetector(
-            onTap: _isSubmitting ? null : () => _onCardSelected(1),
-            child: Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(14),
-              decoration: BoxDecoration(
-                color: const Color(0xFFEEEDFE),
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: const Color(0xFF534AB7),
-                  width: 1,
+          Row(
+            children: _currentCardOptions.map((cardId) {
+              final card = CardInfo.fromId(cardId);
+              if (card == null) return const SizedBox.shrink();
+              return Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 8),
+                  child: _buildCardItem(card),
                 ),
-              ),
-              child: Row(
-                children: [
-                  const Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const Text(
-                          '거인의 어깨',
-                          style: TextStyle(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w700,
-                            color: Color(0xFF3C3489),
-                          ),
-                        ),
-                        const SizedBox(height: 4),
-                        const Text(
-                          '현재 자산의 30%로 S&P500 즉시 매수',
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: Color(0xFF534AB7),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  if (_isSubmitting)
-                    const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: Color(0xFF534AB7),
-                      ),
-                    )
-                  else
-                    const Icon(
-                      Icons.arrow_forward_ios_rounded,
-                      size: 16,
-                      color: Color(0xFF534AB7),
-                    ),
-                ],
-              ),
-            ),
+              );
+            }).toList(),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildNextRoundButton() {
-    final isLastRound = _currentRoundIndex >= _session.totalRounds - 1;
-
-    return SizedBox(
-      width: double.infinity,
-      height: 52,
-      child: ElevatedButton(
-        onPressed: isLastRound
-            ? null
-            : () => setState(() => _currentRoundIndex++),
-        style: ElevatedButton.styleFrom(
-          backgroundColor: isLastRound
-              ? const Color(0xFFEEEEEE)
-              : const Color(0xFF111111),
-          foregroundColor: isLastRound
-              ? const Color(0xFFAAAAAA)
-              : Colors.white,
-          elevation: 0,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(14),
-          ),
+  Widget _buildCardItem(CardInfo card) {
+    return GestureDetector(
+      onTap: _isSubmitting ? null : () => _onCardSelected(card.id),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: const Color(0xFFEEEDFE),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: const Color(0xFF534AB7), width: 1),
         ),
-        child: Text(
-          isLastRound
-              ? '게임 종료'
-              : '다음 라운드 (${_currentRoundIndex + 2}/${_session.totalRounds})',
-          style: const TextStyle(
-            fontSize: 15,
-            fontWeight: FontWeight.w700,
-          ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(card.emoji, style: const TextStyle(fontSize: 22)),
+            const SizedBox(height: 6),
+            Text(card.name,
+              style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w700, color: Color(0xFF3C3489))),
+            const SizedBox(height: 4),
+            Text(card.description,
+              style: const TextStyle(fontSize: 10, color: Color(0xFF534AB7), height: 1.4)),
+          ],
         ),
       ),
+    );
+  }
+
+  // ── 수동/자동 컨트롤 ────────────────────────
+  Widget _buildControls() {
+    return Row(
+      children: [
+        // 자동 재생 토글
+        GestureDetector(
+          onTap: _isAutoPlaying ? _stopAutoPlay : _startAutoPlay,
+          child: Container(
+            width: 52, height: 52,
+            decoration: BoxDecoration(
+              color: _isAutoPlaying ? const Color(0xFF3C3489) : Colors.white,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
+            ),
+            child: Icon(
+              _isAutoPlaying ? Icons.pause_rounded : Icons.play_arrow_rounded,
+              color: _isAutoPlaying ? Colors.white : const Color(0xFF111111),
+              size: 24,
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+
+        // 다음 라운드 버튼
+        Expanded(
+          child: SizedBox(
+            height: 52,
+            child: ElevatedButton(
+              onPressed: (_isLastRound || _isAutoPlaying) ? null : _nextRound,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: _isLastRound ? const Color(0xFFEEEEEE) : const Color(0xFF111111),
+                foregroundColor: _isLastRound ? const Color(0xFFAAAAAA) : Colors.white,
+                elevation: 0,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+              ),
+              child: Text(
+                _isLastRound ? '게임 종료' : '다음 라운드 ($_currentRound1 / ${_session.totalRounds})',
+                style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/frontEnd/lib/screens/scenario_screen.dart
+++ b/frontEnd/lib/screens/scenario_screen.dart
@@ -24,8 +24,7 @@ class _ScenarioScreenState extends State<ScenarioScreen> {
   @override
   void initState() {
     super.initState();
-    // 앱 시작 시 자동으로 불러오지 않음
-    // 버튼으로 직접 선택해서 불러오도록 변경
+    _loadScenarios(); // 진입하자마자 자동 호출
   }
 
   // 실제 API 호출
@@ -51,10 +50,8 @@ class _ScenarioScreenState extends State<ScenarioScreen> {
   // 임시 데이터로 불러오기 (fromJson 거침)
   void _loadMockScenarios() {
     setState(() => _isLoading = true);
-
     final List<dynamic> list = MockData.scenarios['data'] as List<dynamic>;
     final scenarios = list.map((json) => Scenario.fromJson(json)).toList();
-
     setState(() {
       _scenarios = scenarios;
       _isLoading = false;
@@ -79,14 +76,12 @@ class _ScenarioScreenState extends State<ScenarioScreen> {
           content: Text(e.toString()),
           backgroundColor: Colors.red[700],
           behavior: SnackBarBehavior.floating,
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
         ),
       );
     }
   }
 
-  // 임시 데이터로 게임 시작 (fromJson 거침)
   void _startMockGame(Scenario scenario) {
     final gameSession = GameSession.fromJson(
       MockData.gameSession['data'] as Map<String, dynamic>,
@@ -109,7 +104,7 @@ class _ScenarioScreenState extends State<ScenarioScreen> {
             children: [
               _buildHeader(),
               const SizedBox(height: 20),
-              _buildMockButtons(), // 임시 버튼
+              _buildMockButtons(),
               const SizedBox(height: 20),
               Expanded(child: _buildBody()),
             ],
@@ -119,7 +114,6 @@ class _ScenarioScreenState extends State<ScenarioScreen> {
     );
   }
 
-  // 임시 데이터 버튼 영역
   Widget _buildMockButtons() {
     return Container(
       padding: const EdgeInsets.all(12),
@@ -142,6 +136,15 @@ class _ScenarioScreenState extends State<ScenarioScreen> {
           const SizedBox(height: 8),
           Row(
             children: [
+              // 수동 API 요청 버튼
+              Expanded(
+                child: _mockButton(
+                  label: '시나리오 수동 요청',
+                  onTap: _loadScenarios,
+                ),
+              ),
+              const SizedBox(width: 8),
+              // 임시 mock 데이터 버튼
               Expanded(
                 child: _mockButton(
                   label: '임시 시나리오 불러오기',
@@ -149,9 +152,10 @@ class _ScenarioScreenState extends State<ScenarioScreen> {
                 ),
               ),
               const SizedBox(width: 8),
+              // 임시 게임 바로 시작
               Expanded(
                 child: _mockButton(
-                  label: '임시 게임 바로 시작',
+                  label: '임시 게임 시작',
                   onTap: _scenarios.isEmpty
                       ? null
                       : () => _startMockGame(_scenarios[0]),
@@ -171,19 +175,22 @@ class _ScenarioScreenState extends State<ScenarioScreen> {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 10),
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 6),
         decoration: BoxDecoration(
-          color:
-              onTap == null ? const Color(0xFFEEEEEE) : const Color(0xFF111111),
+          color: onTap == null
+              ? const Color(0xFFEEEEEE)
+              : const Color(0xFF111111),
           borderRadius: BorderRadius.circular(8),
         ),
         child: Text(
           label,
           textAlign: TextAlign.center,
           style: TextStyle(
-            fontSize: 11,
+            fontSize: 10,
             fontWeight: FontWeight.w600,
-            color: onTap == null ? const Color(0xFFAAAAAA) : Colors.white,
+            color: onTap == null
+                ? const Color(0xFFAAAAAA)
+                : Colors.white,
           ),
         ),
       ),
@@ -199,15 +206,35 @@ class _ScenarioScreenState extends State<ScenarioScreen> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            const Icon(Icons.wifi_off_rounded, size: 36, color: Color(0xFF6B7684)),
+            const SizedBox(height: 12),
             Text(
               _errorMessage!,
               style: const TextStyle(color: Color(0xFF6B7684)),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 16),
-            TextButton(
-              onPressed: _loadScenarios,
-              child: const Text('다시 시도'),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextButton(
+                  onPressed: _loadScenarios,
+                  child: const Text('다시 시도'),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: _loadMockScenarios,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF111111),
+                    foregroundColor: Colors.white,
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  child: const Text('임시 데이터로 계속', style: TextStyle(fontSize: 13)),
+                ),
+              ],
             ),
           ],
         ),
@@ -216,7 +243,7 @@ class _ScenarioScreenState extends State<ScenarioScreen> {
     if (_scenarios.isEmpty) {
       return const Center(
         child: Text(
-          '위 버튼으로 시나리오를 불러오세요',
+          '시나리오를 불러올 수 없어요',
           style: TextStyle(color: Color(0xFF6B7684)),
         ),
       );

--- a/frontEnd/lib/services/api_client.dart
+++ b/frontEnd/lib/services/api_client.dart
@@ -1,7 +1,9 @@
 import 'package:dio/dio.dart';
 
 class ApiClient {
-  static const String _baseUrl = 'http://10.38.67.231:8080';
+  //static const String _baseUrl = 'http://172.22.165.231:8080';
+  static const String _baseUrl = 'http://172.18.16.192:8080';
+  
 
   final Dio _dio = Dio(BaseOptions(
     baseUrl: _baseUrl,

--- a/frontEnd/lib/services/mock_data.dart
+++ b/frontEnd/lib/services/mock_data.dart
@@ -1,146 +1,1001 @@
+// 실제 API 연결 전 테스트용 임시 데이터
+// 서버와 동일한 구조
+// /game/start  → rounds 1개
+// /game/action → 구간별 rounds (1~24, 25~49, 50~74, 75~100)
 class MockData {
 
   static Map<String, dynamic> scenarios = {
     "success": true,
     "message": "OK",
     "data": [
-      {
-        "id": 1,
-        "title": "리먼브라더스 사태",
-        "year": 2008,
-        "difficulty": 5,
-        "description": "2008년 금융위기. 역사상 최악의 시장 붕괴.",
-        "colorHex": "FAECE7",
-      },
-      {
-        "id": 2,
-        "title": "닷컴버블 붕괴",
-        "year": 2000,
-        "difficulty": 4,
-        "description": "인터넷 버블이 터지며 나스닥 80% 폭락.",
-        "colorHex": "FAEEDA",
-      },
-      {
-        "id": 3,
-        "title": "코로나 쇼크",
-        "year": 2020,
-        "difficulty": 3,
-        "description": "팬데믹으로 인한 급격한 시장 변동.",
-        "colorHex": "E6F1FB",
-      },
+      {"id": 1, "title": "리먼브라더스 사태", "year": 2008, "difficulty": 5, "description": "2008년 금융위기.", "colorHex": "FAECE7"},
+      {"id": 2, "title": "닷컴버블 붕괴", "year": 2000, "difficulty": 4, "description": "인터넷 버블이 터지며 나스닥 80% 폭락.", "colorHex": "FAEEDA"},
+      {"id": 3, "title": "코로나 쇼크", "year": 2020, "difficulty": 3, "description": "팬데믹으로 인한 급격한 시장 변동.", "colorHex": "E6F1FB"},
     ]
   };
 
-  // POST /game/start 응답 (카드 선택 전 — roundAsset, returnRate 없음)
+  // POST /game/start 응답 (서버와 동일: rounds 1개만)
   static Map<String, dynamic> gameSession = {
     "success": true,
     "message": "OK",
     "data": {
       "sessionId": "mock-session-001",
       "scenarioTitle": "리먼브라더스 사태",
-      "totalRounds": 10,
+      "totalRounds": 100,
       "initialAsset": 10000000,
+      "cardSelectRounds": [1, 25, 50, 75],
+      "firstCardOptions": [1, 2, 3],
       "rounds": [
-        {"round": 1, "date": "2008-01-02", "priceData": [
-          {"ticker": "^SPX", "open": 1447.16, "close": 1411.63, "high": 1450.23, "low": 1403.97, "changeRate": -2.46},
-          {"ticker": "^NDX", "open": 2069.85, "close": 2017.49, "high": 2072.10, "low": 2011.12, "changeRate": -2.53},
-        ]},
-        {"round": 2, "date": "2008-01-03", "priceData": [
-          {"ticker": "^SPX", "open": 1411.63, "close": 1447.16, "high": 1452.00, "low": 1408.00, "changeRate": 2.52},
-          {"ticker": "^NDX", "open": 2017.49, "close": 2050.22, "high": 2058.00, "low": 2013.00, "changeRate": 1.62},
-        ]},
-        {"round": 3, "date": "2008-01-04", "priceData": [
-          {"ticker": "^SPX", "open": 1447.16, "close": 1411.00, "high": 1450.00, "low": 1405.00, "changeRate": -2.50},
-          {"ticker": "^NDX", "open": 2050.22, "close": 1990.00, "high": 2055.00, "low": 1985.00, "changeRate": -2.94},
-        ]},
-        {"round": 4, "date": "2008-01-07", "priceData": [
-          {"ticker": "^SPX", "open": 1411.00, "close": 1390.00, "high": 1415.00, "low": 1385.00, "changeRate": -1.49},
-          {"ticker": "^NDX", "open": 1990.00, "close": 1965.00, "high": 1995.00, "low": 1960.00, "changeRate": -1.26},
-        ]},
-        {"round": 5, "date": "2008-01-08", "priceData": [
-          {"ticker": "^SPX", "open": 1390.00, "close": 1360.00, "high": 1392.00, "low": 1355.00, "changeRate": -2.16},
-          {"ticker": "^NDX", "open": 1965.00, "close": 1920.00, "high": 1968.00, "low": 1915.00, "changeRate": -2.29},
-        ]},
-        {"round": 6, "date": "2008-01-09", "priceData": [
-          {"ticker": "^SPX", "open": 1360.00, "close": 1380.00, "high": 1385.00, "low": 1355.00, "changeRate": 1.47},
-          {"ticker": "^NDX", "open": 1920.00, "close": 1945.00, "high": 1950.00, "low": 1915.00, "changeRate": 1.30},
-        ]},
-        {"round": 7, "date": "2008-01-10", "priceData": [
-          {"ticker": "^SPX", "open": 1380.00, "close": 1370.00, "high": 1385.00, "low": 1362.00, "changeRate": -0.72},
-          {"ticker": "^NDX", "open": 1945.00, "close": 1930.00, "high": 1950.00, "low": 1925.00, "changeRate": -0.77},
-        ]},
-        {"round": 8, "date": "2008-01-11", "priceData": [
-          {"ticker": "^SPX", "open": 1370.00, "close": 1340.00, "high": 1372.00, "low": 1335.00, "changeRate": -2.19},
-          {"ticker": "^NDX", "open": 1930.00, "close": 1890.00, "high": 1932.00, "low": 1885.00, "changeRate": -2.07},
-        ]},
-        {"round": 9, "date": "2008-01-14", "priceData": [
-          {"ticker": "^SPX", "open": 1340.00, "close": 1325.00, "high": 1345.00, "low": 1320.00, "changeRate": -1.12},
-          {"ticker": "^NDX", "open": 1890.00, "close": 1860.00, "high": 1895.00, "low": 1855.00, "changeRate": -1.59},
-        ]},
-        {"round": 10, "date": "2008-01-15", "priceData": [
-          {"ticker": "^SPX", "open": 1325.00, "close": 1276.60, "high": 1328.00, "low": 1270.00, "changeRate": -3.65},
-          {"ticker": "^NDX", "open": 1860.00, "close": 1790.00, "high": 1862.00, "low": 1785.00, "changeRate": -3.76},
-        ]},
+        {
+          "round": 1,
+          "date": "2008-09-02",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1274.04, "close": 1286.01, "high": 1290.75, "low": 1269.73, "changeRate": 0.66},
+          {"ticker": "^NDX", "open": 1726.75, "close": 1654.47, "high": 1727.5, "low": 1650.98, "changeRate": -3.81},
+          {"ticker": "GLD", "open": 84.76, "close": 84.35, "high": 84.82, "low": 84.22, "changeRate": -0.76}
+          ]
+        }
       ]
     }
   };
 
-  // POST /game/round/action 응답
-  // "거인의 어깨" 카드 선택 후 1~10라운드 결과
-  // 초기자산 10,000,000 → 30% = 3,000,000 SPX 매수
-  // 매수 시점 SPX 종가: 1411.63 → 수량: 3,000,000 / 1411.63 = 2124.5주
-  static Map<String, dynamic> actionResult = {
+  // POST /game/round/action — 1라운드 카드 선택 (round 1~24)
+  static Map<String, dynamic> actionResult1 = {
     "success": true,
     "message": "OK",
     "data": {
       "selectedCard": "거인의 어깨",
-      "nextEventRound": null,  // 다음 증강 없음
+      "nextEventRound": 25,
+      "nextCardOptions": [4, 5, 2],
       "rounds": [
-        // 1라운드: 매수 시점
-        // 현금: 7,000,000 / 보유SPX: 2124.5주 × 1411.63 = 2,999,977
-        // roundAsset = 7,000,000 + 2,999,977 = 9,999,977
-        {"round": 1, "date": "2008-01-02", "priceData": [
-          {"ticker": "^SPX", "open": 1447.16, "close": 1411.63, "high": 1450.23, "low": 1403.97, "changeRate": -2.46},
-        ], "roundAsset": 9999977, "returnRate": -0.0},
-
-        // 2라운드: SPX 1447.16
-        // roundAsset = 7,000,000 + 2124.5 × 1447.16 = 7,000,000 + 3,075,408 = 10,075,408
-        {"round": 2, "date": "2008-01-03", "priceData": [
-          {"ticker": "^SPX", "open": 1411.63, "close": 1447.16, "high": 1452.00, "low": 1408.00, "changeRate": 2.52},
-        ], "roundAsset": 10075408, "returnRate": 0.75},
-
-        {"round": 3, "date": "2008-01-04", "priceData": [
-          {"ticker": "^SPX", "open": 1447.16, "close": 1411.00, "high": 1450.00, "low": 1405.00, "changeRate": -2.50},
-        ], "roundAsset": 9998695, "returnRate": -0.01},
-
-        {"round": 4, "date": "2008-01-07", "priceData": [
-          {"ticker": "^SPX", "open": 1411.00, "close": 1390.00, "high": 1415.00, "low": 1385.00, "changeRate": -1.49},
-        ], "roundAsset": 9954045, "returnRate": -0.46},
-
-        {"round": 5, "date": "2008-01-08", "priceData": [
-          {"ticker": "^SPX", "open": 1390.00, "close": 1360.00, "high": 1392.00, "low": 1355.00, "changeRate": -2.16},
-        ], "roundAsset": 9890302, "returnRate": -1.10},
-
-        {"round": 6, "date": "2008-01-09", "priceData": [
-          {"ticker": "^SPX", "open": 1360.00, "close": 1380.00, "high": 1385.00, "low": 1355.00, "changeRate": 1.47},
-        ], "roundAsset": 9932810, "returnRate": -0.67},
-
-        {"round": 7, "date": "2008-01-10", "priceData": [
-          {"ticker": "^SPX", "open": 1380.00, "close": 1370.00, "high": 1385.00, "low": 1362.00, "changeRate": -0.72},
-        ], "roundAsset": 9911595, "returnRate": -0.88},
-
-        {"round": 8, "date": "2008-01-11", "priceData": [
-          {"ticker": "^SPX", "open": 1370.00, "close": 1340.00, "high": 1372.00, "low": 1335.00, "changeRate": -2.19},
-        ], "roundAsset": 9847820, "returnRate": -1.52},
-
-        {"round": 9, "date": "2008-01-14", "priceData": [
-          {"ticker": "^SPX", "open": 1340.00, "close": 1325.00, "high": 1345.00, "low": 1320.00, "changeRate": -1.12},
-        ], "roundAsset": 9815963, "returnRate": -1.84},
-
-        {"round": 10, "date": "2008-01-15", "priceData": [
-          {"ticker": "^SPX", "open": 1325.00, "close": 1276.60, "high": 1328.00, "low": 1270.00, "changeRate": -3.65},
-        ], "roundAsset": 9712879, "returnRate": -2.87},
+        {
+          "round": 1,
+          "date": "2008-09-02",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1274.04, "close": 1286.01, "high": 1290.75, "low": 1269.73, "changeRate": 0.66},
+          {"ticker": "^NDX", "open": 1726.75, "close": 1654.47, "high": 1727.5, "low": 1650.98, "changeRate": -3.81},
+          {"ticker": "GLD", "open": 84.76, "close": 84.35, "high": 84.82, "low": 84.22, "changeRate": -0.76}
+          ], "roundAsset": 10000000, "returnRate": 0.0
+        },
+        {
+          "round": 2,
+          "date": "2008-09-03",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1286.59, "close": 1243.19, "high": 1288.01, "low": 1239.53, "changeRate": -3.33},
+          {"ticker": "^NDX", "open": 1659.59, "close": 1612.94, "high": 1659.64, "low": 1606.44, "changeRate": -2.51},
+          {"ticker": "GLD", "open": 84.45, "close": 85.13, "high": 85.22, "low": 84.41, "changeRate": 0.92}
+          ], "roundAsset": 9900110, "returnRate": -1.0
+        },
+        {
+          "round": 3,
+          "date": "2008-09-04",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1238.18, "close": 1277.0, "high": 1282.41, "low": 1234.44, "changeRate": 2.72},
+          {"ticker": "^NDX", "open": 1617.89, "close": 1589.07, "high": 1623.79, "low": 1584.81, "changeRate": -1.48},
+          {"ticker": "GLD", "open": 85.37, "close": 83.78, "high": 85.47, "low": 83.64, "changeRate": -1.58}
+          ], "roundAsset": 9978982, "returnRate": -0.21
+        },
+        {
+          "round": 4,
+          "date": "2008-09-05",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1277.99, "close": 1301.14, "high": 1305.72, "low": 1277.7, "changeRate": 1.89},
+          {"ticker": "^NDX", "open": 1584.75, "close": 1599.24, "high": 1601.55, "low": 1584.12, "changeRate": 0.64},
+          {"ticker": "GLD", "open": 83.65, "close": 85.36, "high": 85.39, "low": 83.58, "changeRate": 1.88}
+          ], "roundAsset": 10035295, "returnRate": 0.35
+        },
+        {
+          "round": 5,
+          "date": "2008-09-08",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1297.36, "close": 1309.34, "high": 1311.09, "low": 1291.28, "changeRate": 0.63},
+          {"ticker": "^NDX", "open": 1601.61, "close": 1579.09, "high": 1606.49, "low": 1577.74, "changeRate": -1.26},
+          {"ticker": "GLD", "open": 85.48, "close": 85.08, "high": 85.52, "low": 84.98, "changeRate": -0.33}
+          ], "roundAsset": 10054424, "returnRate": 0.54
+        },
+        {
+          "round": 6,
+          "date": "2008-09-09",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1311.76, "close": 1347.7, "high": 1353.38, "low": 1306.67, "changeRate": 2.93},
+          {"ticker": "^NDX", "open": 1574.81, "close": 1591.72, "high": 1591.98, "low": 1572.33, "changeRate": 0.8},
+          {"ticker": "GLD", "open": 84.96, "close": 85.51, "high": 85.56, "low": 84.72, "changeRate": 0.51}
+          ], "roundAsset": 10143910, "returnRate": 1.44
+        },
+        {
+          "round": 7,
+          "date": "2008-09-10",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1346.29, "close": 1377.35, "high": 1383.65, "low": 1343.2, "changeRate": 2.2},
+          {"ticker": "^NDX", "open": 1587.98, "close": 1565.62, "high": 1589.94, "low": 1561.23, "changeRate": -1.64},
+          {"ticker": "GLD", "open": 85.39, "close": 86.32, "high": 86.47, "low": 85.16, "changeRate": 0.95}
+          ], "roundAsset": 10213078, "returnRate": 2.13
+        },
+        {
+          "round": 8,
+          "date": "2008-09-11",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1377.48, "close": 1364.95, "high": 1378.11, "low": 1364.63, "changeRate": -0.9},
+          {"ticker": "^NDX", "open": 1559.51, "close": 1528.67, "high": 1564.4, "low": 1522.62, "changeRate": -2.36},
+          {"ticker": "GLD", "open": 86.28, "close": 88.47, "high": 88.49, "low": 86.18, "changeRate": 2.49}
+          ], "roundAsset": 10184151, "returnRate": 1.84
+        },
+        {
+          "round": 9,
+          "date": "2008-09-12",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1369.87, "close": 1405.49, "high": 1405.57, "low": 1364.93, "changeRate": 2.97},
+          {"ticker": "^NDX", "open": 1531.45, "close": 1528.21, "high": 1535.56, "low": 1526.17, "changeRate": -0.03},
+          {"ticker": "GLD", "open": 88.54, "close": 90.57, "high": 90.6, "low": 88.42, "changeRate": 2.37}
+          ], "roundAsset": 10278723, "returnRate": 2.79
+        },
+        {
+          "round": 10,
+          "date": "2008-09-15",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1402.16, "close": 1397.76, "high": 1405.67, "low": 1396.51, "changeRate": -0.55},
+          {"ticker": "^NDX", "open": 1534.52, "close": 1576.35, "high": 1583.21, "low": 1532.23, "changeRate": 3.15},
+          {"ticker": "GLD", "open": 90.65, "close": 92.33, "high": 92.5, "low": 90.61, "changeRate": 1.94}
+          ], "roundAsset": 10260690, "returnRate": 2.61
+        },
+        {
+          "round": 11,
+          "date": "2008-09-16",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1398.18, "close": 1418.17, "high": 1418.17, "low": 1395.91, "changeRate": 1.46},
+          {"ticker": "^NDX", "open": 1568.78, "close": 1577.14, "high": 1584.47, "low": 1561.89, "changeRate": 0.05},
+          {"ticker": "GLD", "open": 92.51, "close": 93.71, "high": 93.8, "low": 92.49, "changeRate": 1.5}
+          ], "roundAsset": 10308302, "returnRate": 3.08
+        },
+        {
+          "round": 12,
+          "date": "2008-09-17",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1417.97, "close": 1449.51, "high": 1450.01, "low": 1412.58, "changeRate": 2.21},
+          {"ticker": "^NDX", "open": 1581.33, "close": 1626.03, "high": 1627.07, "low": 1577.57, "changeRate": 3.1},
+          {"ticker": "GLD", "open": 93.74, "close": 92.2, "high": 93.81, "low": 91.96, "changeRate": -1.61}
+          ], "roundAsset": 10381412, "returnRate": 3.81
+        },
+        {
+          "round": 13,
+          "date": "2008-09-18",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1452.84, "close": 1438.64, "high": 1454.3, "low": 1436.4, "changeRate": -0.75},
+          {"ticker": "^NDX", "open": 1634.08, "close": 1586.84, "high": 1639.39, "low": 1583.36, "changeRate": -2.41},
+          {"ticker": "GLD", "open": 92.21, "close": 92.6, "high": 92.63, "low": 92.15, "changeRate": 0.43}
+          ], "roundAsset": 10356055, "returnRate": 3.56
+        },
+        {
+          "round": 14,
+          "date": "2008-09-19",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1434.61, "close": 1419.94, "high": 1435.12, "low": 1415.46, "changeRate": -1.3},
+          {"ticker": "^NDX", "open": 1582.54, "close": 1593.35, "high": 1600.56, "low": 1575.74, "changeRate": 0.41},
+          {"ticker": "GLD", "open": 92.36, "close": 91.71, "high": 92.43, "low": 91.53, "changeRate": -0.96}
+          ], "roundAsset": 10312431, "returnRate": 3.12
+        },
+        {
+          "round": 15,
+          "date": "2008-09-22",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1420.95, "close": 1389.98, "high": 1424.31, "low": 1384.53, "changeRate": -2.11},
+          {"ticker": "^NDX", "open": 1598.25, "close": 1545.39, "high": 1599.77, "low": 1544.64, "changeRate": -3.01},
+          {"ticker": "GLD", "open": 91.67, "close": 93.74, "high": 93.86, "low": 91.54, "changeRate": 2.21}
+          ], "roundAsset": 10242541, "returnRate": 2.43
+        },
+        {
+          "round": 16,
+          "date": "2008-09-23",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1384.4, "close": 1407.22, "high": 1410.05, "low": 1382.05, "changeRate": 1.24},
+          {"ticker": "^NDX", "open": 1550.98, "close": 1561.62, "high": 1563.56, "low": 1549.5, "changeRate": 1.05},
+          {"ticker": "GLD", "open": 93.71, "close": 96.02, "high": 96.14, "low": 93.63, "changeRate": 2.43}
+          ], "roundAsset": 10282758, "returnRate": 2.83
+        },
+        {
+          "round": 17,
+          "date": "2008-09-24",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1412.3, "close": 1380.76, "high": 1416.19, "low": 1380.41, "changeRate": -1.88},
+          {"ticker": "^NDX", "open": 1569.42, "close": 1607.22, "high": 1613.94, "low": 1561.82, "changeRate": 2.92},
+          {"ticker": "GLD", "open": 96.27, "close": 96.01, "high": 96.52, "low": 95.96, "changeRate": -0.01}
+          ], "roundAsset": 10221032, "returnRate": 2.21
+        },
+        {
+          "round": 18,
+          "date": "2008-09-25",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1374.67, "close": 1376.07, "high": 1378.68, "low": 1367.9, "changeRate": -0.34},
+          {"ticker": "^NDX", "open": 1603.45, "close": 1568.65, "high": 1609.74, "low": 1565.08, "changeRate": -2.4},
+          {"ticker": "GLD", "open": 95.97, "close": 95.82, "high": 96.25, "low": 95.53, "changeRate": -0.2}
+          ], "roundAsset": 10210092, "returnRate": 2.1
+        },
+        {
+          "round": 19,
+          "date": "2008-09-26",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1373.27, "close": 1377.58, "high": 1384.25, "low": 1369.29, "changeRate": 0.11},
+          {"ticker": "^NDX", "open": 1569.31, "close": 1590.45, "high": 1596.4, "low": 1568.86, "changeRate": 1.39},
+          {"ticker": "GLD", "open": 95.87, "close": 94.57, "high": 96.01, "low": 94.33, "changeRate": -1.3}
+          ], "roundAsset": 10213614, "returnRate": 2.14
+        },
+        {
+          "round": 20,
+          "date": "2008-09-29",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1373.25, "close": 1343.42, "high": 1377.34, "low": 1338.88, "changeRate": -2.48},
+          {"ticker": "^NDX", "open": 1586.24, "close": 1641.5, "high": 1642.48, "low": 1579.18, "changeRate": 3.21},
+          {"ticker": "GLD", "open": 94.43, "close": 93.02, "high": 94.6, "low": 92.85, "changeRate": -1.64}
+          ], "roundAsset": 10133926, "returnRate": 1.34
+        },
+        {
+          "round": 21,
+          "date": "2008-09-30",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1349.26, "close": 1332.94, "high": 1350.64, "low": 1328.17, "changeRate": -0.78},
+          {"ticker": "^NDX", "open": 1637.21, "close": 1647.74, "high": 1651.0, "low": 1631.71, "changeRate": 0.38},
+          {"ticker": "GLD", "open": 92.91, "close": 93.35, "high": 93.44, "low": 92.7, "changeRate": 0.35}
+          ], "roundAsset": 10109478, "returnRate": 1.09
+        },
+        {
+          "round": 22,
+          "date": "2008-10-01",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1339.55, "close": 1292.55, "high": 1340.04, "low": 1291.17, "changeRate": -3.03},
+          {"ticker": "^NDX", "open": 1643.87, "close": 1638.51, "high": 1651.54, "low": 1631.29, "changeRate": -0.56},
+          {"ticker": "GLD", "open": 93.56, "close": 95.67, "high": 95.78, "low": 93.52, "changeRate": 2.49}
+          ], "roundAsset": 10015256, "returnRate": 0.15
+        },
+        {
+          "round": 23,
+          "date": "2008-10-02",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1298.85, "close": 1317.37, "high": 1321.68, "low": 1298.8, "changeRate": 1.92},
+          {"ticker": "^NDX", "open": 1643.71, "close": 1659.48, "high": 1661.96, "low": 1638.26, "changeRate": 1.28},
+          {"ticker": "GLD", "open": 95.92, "close": 96.39, "high": 96.43, "low": 95.89, "changeRate": 0.75}
+          ], "roundAsset": 10073157, "returnRate": 0.73
+        },
+        {
+          "round": 24,
+          "date": "2008-10-03",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1318.75, "close": 1280.48, "high": 1323.48, "low": 1279.18, "changeRate": -2.8},
+          {"ticker": "^NDX", "open": 1661.71, "close": 1661.97, "high": 1664.16, "low": 1657.65, "changeRate": 0.15},
+          {"ticker": "GLD", "open": 96.62, "close": 95.65, "high": 96.87, "low": 95.62, "changeRate": -0.77}
+          ], "roundAsset": 9987100, "returnRate": -0.13
+        }
       ]
     }
   };
+
+  // POST /game/round/action — 25라운드 카드 선택 (round 25~49)
+  static Map<String, dynamic> actionResult2 = {
+    "success": true,
+    "message": "OK",
+    "data": {
+      "selectedCard": "황금 적립",
+      "nextEventRound": 50,
+      "nextCardOptions": [3, 6, 5],
+      "rounds": [
+        {
+          "round": 25,
+          "date": "2008-10-06",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1283.95, "close": 1270.88, "high": 1288.04, "low": 1269.22, "changeRate": -0.75},
+          {"ticker": "^NDX", "open": 1665.98, "close": 1630.06, "high": 1670.58, "low": 1626.57, "changeRate": -1.92},
+          {"ticker": "GLD", "open": 95.37, "close": 93.76, "high": 95.39, "low": 93.51, "changeRate": -1.98}
+          ], "roundAsset": 9987100, "returnRate": 0.0
+        },
+        {
+          "round": 26,
+          "date": "2008-10-07",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1271.93, "close": 1301.13, "high": 1302.09, "low": 1271.12, "changeRate": 2.38},
+          {"ticker": "^NDX", "open": 1626.93, "close": 1631.53, "high": 1638.86, "low": 1620.45, "changeRate": 0.09},
+          {"ticker": "GLD", "open": 93.96, "close": 95.41, "high": 95.67, "low": 93.9, "changeRate": 1.76}
+          ], "roundAsset": 10058415, "returnRate": 0.71
+        },
+        {
+          "round": 27,
+          "date": "2008-10-08",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1306.13, "close": 1276.67, "high": 1308.78, "low": 1272.71, "changeRate": -1.88},
+          {"ticker": "^NDX", "open": 1625.89, "close": 1578.83, "high": 1633.45, "low": 1572.0, "changeRate": -3.23},
+          {"ticker": "GLD", "open": 95.68, "close": 96.85, "high": 97.09, "low": 95.43, "changeRate": 1.51}
+          ], "roundAsset": 10000750, "returnRate": 0.14
+        },
+        {
+          "round": 28,
+          "date": "2008-10-09",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1282.17, "close": 1234.03, "high": 1287.31, "low": 1228.7, "changeRate": -3.34},
+          {"ticker": "^NDX", "open": 1583.74, "close": 1602.83, "high": 1604.97, "low": 1577.51, "changeRate": 1.52},
+          {"ticker": "GLD", "open": 96.62, "close": 96.36, "high": 96.87, "low": 96.11, "changeRate": -0.51}
+          ], "roundAsset": 9900225, "returnRate": -0.87
+        },
+        {
+          "round": 29,
+          "date": "2008-10-10",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1231.63, "close": 1208.73, "high": 1236.53, "low": 1207.35, "changeRate": -2.05},
+          {"ticker": "^NDX", "open": 1595.2, "close": 1636.81, "high": 1638.39, "low": 1592.58, "changeRate": 2.12},
+          {"ticker": "GLD", "open": 96.57, "close": 96.43, "high": 96.85, "low": 96.35, "changeRate": 0.07}
+          ], "roundAsset": 9840580, "returnRate": -1.47
+        },
+        {
+          "round": 30,
+          "date": "2008-10-13",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1209.17, "close": 1216.83, "high": 1222.54, "low": 1208.47, "changeRate": 0.67},
+          {"ticker": "^NDX", "open": 1644.51, "close": 1620.44, "high": 1645.98, "low": 1612.64, "changeRate": -1.0},
+          {"ticker": "GLD", "open": 96.29, "close": 98.76, "high": 98.79, "low": 96.16, "changeRate": 2.42}
+          ], "roundAsset": 9859676, "returnRate": -1.28
+        },
+        {
+          "round": 31,
+          "date": "2008-10-14",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1216.97, "close": 1231.92, "high": 1234.29, "low": 1213.46, "changeRate": 1.24},
+          {"ticker": "^NDX", "open": 1616.47, "close": 1593.7, "high": 1622.2, "low": 1593.69, "changeRate": -1.65},
+          {"ticker": "GLD", "open": 99.01, "close": 99.48, "high": 99.64, "low": 98.8, "changeRate": 0.73}
+          ], "roundAsset": 9895251, "returnRate": -0.92
+        },
+        {
+          "round": 32,
+          "date": "2008-10-15",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1226.62, "close": 1248.18, "high": 1252.33, "low": 1224.59, "changeRate": 1.32},
+          {"ticker": "^NDX", "open": 1590.73, "close": 1610.12, "high": 1616.95, "low": 1585.01, "changeRate": 1.03},
+          {"ticker": "GLD", "open": 99.36, "close": 99.12, "high": 99.45, "low": 99.0, "changeRate": -0.36}
+          ], "roundAsset": 9933584, "returnRate": -0.54
+        },
+        {
+          "round": 33,
+          "date": "2008-10-16",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1247.19, "close": 1237.2, "high": 1253.05, "low": 1233.01, "changeRate": -0.88},
+          {"ticker": "^NDX", "open": 1616.61, "close": 1581.46, "high": 1621.59, "low": 1579.08, "changeRate": -1.78},
+          {"ticker": "GLD", "open": 99.15, "close": 97.7, "high": 99.15, "low": 97.62, "changeRate": -1.43}
+          ], "roundAsset": 9907699, "returnRate": -0.8
+        },
+        {
+          "round": 34,
+          "date": "2008-10-17",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1236.77, "close": 1228.42, "high": 1239.5, "low": 1227.11, "changeRate": -0.71},
+          {"ticker": "^NDX", "open": 1581.04, "close": 1587.0, "high": 1594.15, "low": 1574.75, "changeRate": 0.35},
+          {"ticker": "GLD", "open": 97.51, "close": 98.63, "high": 98.66, "low": 97.36, "changeRate": 0.95}
+          ], "roundAsset": 9887000, "returnRate": -1.0
+        },
+        {
+          "round": 35,
+          "date": "2008-10-20",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1231.51, "close": 1235.91, "high": 1240.07, "low": 1230.13, "changeRate": 0.61},
+          {"ticker": "^NDX", "open": 1582.23, "close": 1563.35, "high": 1582.42, "low": 1561.44, "changeRate": -1.49},
+          {"ticker": "GLD", "open": 98.62, "close": 100.29, "high": 100.55, "low": 98.6, "changeRate": 1.68}
+          ], "roundAsset": 9904657, "returnRate": -0.83
+        },
+        {
+          "round": 36,
+          "date": "2008-10-21",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1238.34, "close": 1225.9, "high": 1241.4, "low": 1224.4, "changeRate": -0.81},
+          {"ticker": "^NDX", "open": 1565.79, "close": 1574.61, "high": 1574.65, "low": 1559.91, "changeRate": 0.72},
+          {"ticker": "GLD", "open": 100.45, "close": 99.16, "high": 100.48, "low": 99.03, "changeRate": -1.13}
+          ], "roundAsset": 9881059, "returnRate": -1.06
+        },
+        {
+          "round": 37,
+          "date": "2008-10-22",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1220.39, "close": 1196.97, "high": 1221.91, "low": 1191.89, "changeRate": -2.36},
+          {"ticker": "^NDX", "open": 1573.92, "close": 1624.68, "high": 1631.19, "low": 1568.67, "changeRate": 3.18},
+          {"ticker": "GLD", "open": 99.45, "close": 99.49, "high": 99.67, "low": 99.17, "changeRate": 0.33}
+          ], "roundAsset": 9812855, "returnRate": -1.74
+        },
+        {
+          "round": 38,
+          "date": "2008-10-23",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1197.03, "close": 1224.38, "high": 1229.46, "low": 1193.75, "changeRate": 2.29},
+          {"ticker": "^NDX", "open": 1631.13, "close": 1634.27, "high": 1640.35, "low": 1627.26, "changeRate": 0.59},
+          {"ticker": "GLD", "open": 99.35, "close": 100.72, "high": 100.79, "low": 99.16, "changeRate": 1.24}
+          ], "roundAsset": 9877475, "returnRate": -1.1
+        },
+        {
+          "round": 39,
+          "date": "2008-10-24",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1221.62, "close": 1242.5, "high": 1242.98, "low": 1219.87, "changeRate": 1.48},
+          {"ticker": "^NDX", "open": 1630.54, "close": 1632.8, "high": 1635.41, "low": 1626.14, "changeRate": -0.09},
+          {"ticker": "GLD", "open": 100.5, "close": 101.55, "high": 101.62, "low": 100.29, "changeRate": 0.82}
+          ], "roundAsset": 9920193, "returnRate": -0.67
+        },
+        {
+          "round": 40,
+          "date": "2008-10-27",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1243.03, "close": 1256.04, "high": 1258.65, "low": 1241.74, "changeRate": 1.09},
+          {"ticker": "^NDX", "open": 1631.5, "close": 1575.33, "high": 1638.88, "low": 1570.73, "changeRate": -3.52},
+          {"ticker": "GLD", "open": 101.67, "close": 101.38, "high": 101.93, "low": 101.15, "changeRate": -0.17}
+          ], "roundAsset": 9952114, "returnRate": -0.35
+        },
+        {
+          "round": 41,
+          "date": "2008-10-28",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1259.22, "close": 1243.1, "high": 1264.59, "low": 1237.17, "changeRate": -1.03},
+          {"ticker": "^NDX", "open": 1574.05, "close": 1512.95, "high": 1579.93, "low": 1508.82, "changeRate": -3.96},
+          {"ticker": "GLD", "open": 101.44, "close": 100.95, "high": 101.51, "low": 100.88, "changeRate": -0.42}
+          ], "roundAsset": 9921608, "returnRate": -0.66
+        },
+        {
+          "round": 42,
+          "date": "2008-10-29",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1245.33, "close": 1234.77, "high": 1247.85, "low": 1233.75, "changeRate": -0.67},
+          {"ticker": "^NDX", "open": 1512.46, "close": 1455.76, "high": 1513.43, "low": 1451.23, "changeRate": -3.78},
+          {"ticker": "GLD", "open": 100.66, "close": 100.46, "high": 100.78, "low": 100.29, "changeRate": -0.49}
+          ], "roundAsset": 9901970, "returnRate": -0.85
+        },
+        {
+          "round": 43,
+          "date": "2008-10-30",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1234.3, "close": 1193.78, "high": 1234.61, "low": 1191.52, "changeRate": -3.32},
+          {"ticker": "^NDX", "open": 1451.56, "close": 1467.7, "high": 1470.1, "low": 1446.04, "changeRate": 0.82},
+          {"ticker": "GLD", "open": 100.39, "close": 99.06, "high": 100.62, "low": 98.81, "changeRate": -1.39}
+          ], "roundAsset": 9805335, "returnRate": -1.82
+        },
+        {
+          "round": 44,
+          "date": "2008-10-31",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1194.25, "close": 1171.58, "high": 1200.22, "low": 1169.53, "changeRate": -1.86},
+          {"ticker": "^NDX", "open": 1469.9, "close": 1417.94, "high": 1475.64, "low": 1413.32, "changeRate": -3.39},
+          {"ticker": "GLD", "open": 99.21, "close": 97.17, "high": 99.49, "low": 97.11, "changeRate": -1.91}
+          ], "roundAsset": 9752998, "returnRate": -2.34
+        },
+        {
+          "round": 45,
+          "date": "2008-11-03",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1173.57, "close": 1132.1, "high": 1176.88, "low": 1130.87, "changeRate": -3.37},
+          {"ticker": "^NDX", "open": 1420.77, "close": 1377.39, "high": 1426.22, "low": 1376.23, "changeRate": -2.86},
+          {"ticker": "GLD", "open": 97.23, "close": 95.78, "high": 97.45, "low": 95.75, "changeRate": -1.43}
+          ], "roundAsset": 9659923, "returnRate": -3.28
+        },
+        {
+          "round": 46,
+          "date": "2008-11-04",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1126.73, "close": 1152.82, "high": 1154.62, "low": 1122.91, "changeRate": 1.83},
+          {"ticker": "^NDX", "open": 1383.7, "close": 1422.02, "high": 1424.84, "low": 1378.75, "changeRate": 3.24},
+          {"ticker": "GLD", "open": 95.54, "close": 94.33, "high": 95.74, "low": 94.15, "changeRate": -1.51}
+          ], "roundAsset": 9708771, "returnRate": -2.79
+        },
+        {
+          "round": 47,
+          "date": "2008-11-05",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1153.98, "close": 1120.08, "high": 1154.68, "low": 1114.57, "changeRate": -2.84},
+          {"ticker": "^NDX", "open": 1426.04, "close": 1447.47, "high": 1449.98, "low": 1422.99, "changeRate": 1.79},
+          {"ticker": "GLD", "open": 94.26, "close": 96.06, "high": 96.21, "low": 94.16, "changeRate": 1.83}
+          ], "roundAsset": 9631585, "returnRate": -3.56
+        },
+        {
+          "round": 48,
+          "date": "2008-11-06",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1125.24, "close": 1142.71, "high": 1146.34, "low": 1120.58, "changeRate": 2.02},
+          {"ticker": "^NDX", "open": 1450.47, "close": 1478.88, "high": 1482.1, "low": 1445.15, "changeRate": 2.17},
+          {"ticker": "GLD", "open": 96.33, "close": 94.59, "high": 96.41, "low": 94.36, "changeRate": -1.53}
+          ], "roundAsset": 9684936, "returnRate": -3.03
+        },
+        {
+          "round": 49,
+          "date": "2008-11-07",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1145.35, "close": 1142.71, "high": 1146.89, "low": 1137.84, "changeRate": -0.0},
+          {"ticker": "^NDX", "open": 1483.77, "close": 1473.41, "high": 1484.41, "low": 1466.91, "changeRate": -0.37},
+          {"ticker": "GLD", "open": 94.44, "close": 94.55, "high": 94.68, "low": 94.27, "changeRate": -0.04}
+          ], "roundAsset": 9684936, "returnRate": -3.03
+        }
+      ]
+    }
+  };
+
+  // POST /game/round/action — 50라운드 카드 선택 (round 50~74)
+  static Map<String, dynamic> actionResult3 = {
+    "success": true,
+    "message": "OK",
+    "data": {
+      "selectedCard": "공포탐욕",
+      "nextEventRound": 75,
+      "nextCardOptions": [4, 6, 2],
+      "rounds": [
+        {
+          "round": 50,
+          "date": "2008-11-10",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1139.07, "close": 1130.83, "high": 1140.28, "low": 1126.32, "changeRate": -1.04},
+          {"ticker": "^NDX", "open": 1471.06, "close": 1417.72, "high": 1477.54, "low": 1412.75, "changeRate": -3.78},
+          {"ticker": "GLD", "open": 94.42, "close": 96.28, "high": 96.28, "low": 94.15, "changeRate": 1.83}
+          ], "roundAsset": 9684936, "returnRate": 0.0
+        },
+        {
+          "round": 51,
+          "date": "2008-11-11",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1133.75, "close": 1097.58, "high": 1137.66, "low": 1094.04, "changeRate": -2.94},
+          {"ticker": "^NDX", "open": 1417.59, "close": 1437.57, "high": 1443.27, "low": 1416.93, "changeRate": 1.4},
+          {"ticker": "GLD", "open": 96.12, "close": 96.47, "high": 96.67, "low": 96.03, "changeRate": 0.2}
+          ], "roundAsset": 9599506, "returnRate": -0.88
+        },
+        {
+          "round": 52,
+          "date": "2008-11-12",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1096.76, "close": 1100.65, "high": 1104.76, "low": 1094.95, "changeRate": 0.28},
+          {"ticker": "^NDX", "open": 1440.49, "close": 1431.1, "high": 1442.44, "low": 1429.3, "changeRate": -0.45},
+          {"ticker": "GLD", "open": 96.25, "close": 96.85, "high": 96.91, "low": 96.22, "changeRate": 0.39}
+          ], "roundAsset": 9607393, "returnRate": -0.8
+        },
+        {
+          "round": 53,
+          "date": "2008-11-13",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1097.53, "close": 1100.43, "high": 1103.09, "low": 1093.55, "changeRate": -0.02},
+          {"ticker": "^NDX", "open": 1437.92, "close": 1455.71, "high": 1459.53, "low": 1435.89, "changeRate": 1.72},
+          {"ticker": "GLD", "open": 96.62, "close": 95.72, "high": 96.68, "low": 95.65, "changeRate": -1.17}
+          ], "roundAsset": 9606828, "returnRate": -0.81
+        },
+        {
+          "round": 54,
+          "date": "2008-11-14",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1097.95, "close": 1074.79, "high": 1103.3, "low": 1071.82, "changeRate": -2.33},
+          {"ticker": "^NDX", "open": 1458.58, "close": 1399.08, "high": 1459.5, "low": 1393.0, "changeRate": -3.89},
+          {"ticker": "GLD", "open": 95.71, "close": 96.1, "high": 96.35, "low": 95.55, "changeRate": 0.4}
+          ], "roundAsset": 9540950, "returnRate": -1.49
+        },
+        {
+          "round": 55,
+          "date": "2008-11-17",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1069.97, "close": 1069.95, "high": 1075.0, "low": 1067.39, "changeRate": -0.45},
+          {"ticker": "^NDX", "open": 1403.59, "close": 1389.29, "high": 1406.4, "low": 1388.78, "changeRate": -0.7},
+          {"ticker": "GLD", "open": 96.17, "close": 94.98, "high": 96.19, "low": 94.94, "changeRate": -1.17}
+          ], "roundAsset": 9528515, "returnRate": -1.62
+        },
+        {
+          "round": 56,
+          "date": "2008-11-18",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1065.87, "close": 1071.66, "high": 1075.76, "low": 1062.64, "changeRate": 0.16},
+          {"ticker": "^NDX", "open": 1393.33, "close": 1365.39, "high": 1394.9, "low": 1361.82, "changeRate": -1.72},
+          {"ticker": "GLD", "open": 94.95, "close": 97.33, "high": 97.46, "low": 94.7, "changeRate": 2.47}
+          ], "roundAsset": 9532908, "returnRate": -1.57
+        },
+        {
+          "round": 57,
+          "date": "2008-11-19",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1072.83, "close": 1103.17, "high": 1107.25, "low": 1067.75, "changeRate": 2.94},
+          {"ticker": "^NDX", "open": 1361.4, "close": 1342.04, "high": 1362.84, "low": 1337.61, "changeRate": -1.71},
+          {"ticker": "GLD", "open": 97.13, "close": 98.1, "high": 98.15, "low": 97.11, "changeRate": 0.79}
+          ], "roundAsset": 9613868, "returnRate": -0.73
+        },
+        {
+          "round": 58,
+          "date": "2008-11-20",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1100.87, "close": 1064.78, "high": 1102.14, "low": 1061.02, "changeRate": -3.48},
+          {"ticker": "^NDX", "open": 1344.76, "close": 1333.72, "high": 1347.81, "low": 1329.14, "changeRate": -0.62},
+          {"ticker": "GLD", "open": 98.35, "close": 98.76, "high": 98.99, "low": 98.17, "changeRate": 0.67}
+          ], "roundAsset": 9515231, "returnRate": -1.75
+        },
+        {
+          "round": 59,
+          "date": "2008-11-21",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1065.25, "close": 1073.3, "high": 1076.78, "low": 1060.41, "changeRate": 0.8},
+          {"ticker": "^NDX", "open": 1338.08, "close": 1373.73, "high": 1374.22, "low": 1336.97, "changeRate": 3.0},
+          {"ticker": "GLD", "open": 98.65, "close": 98.67, "high": 98.89, "low": 98.48, "changeRate": -0.09}
+          ], "roundAsset": 9537122, "returnRate": -1.53
+        },
+        {
+          "round": 60,
+          "date": "2008-11-24",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1075.44, "close": 1055.91, "high": 1080.51, "low": 1053.27, "changeRate": -1.62},
+          {"ticker": "^NDX", "open": 1373.64, "close": 1331.56, "high": 1374.19, "low": 1331.29, "changeRate": -3.07},
+          {"ticker": "GLD", "open": 98.63, "close": 99.76, "high": 99.86, "low": 98.56, "changeRate": 1.1}
+          ], "roundAsset": 9492441, "returnRate": -1.99
+        },
+        {
+          "round": 61,
+          "date": "2008-11-25",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1056.7, "close": 1025.18, "high": 1061.72, "low": 1020.06, "changeRate": -2.91},
+          {"ticker": "^NDX", "open": 1333.85, "close": 1374.3, "high": 1376.15, "low": 1333.58, "changeRate": 3.21},
+          {"ticker": "GLD", "open": 99.91, "close": 101.52, "high": 101.66, "low": 99.71, "changeRate": 1.76}
+          ], "roundAsset": 9413486, "returnRate": -2.8
+        },
+        {
+          "round": 62,
+          "date": "2008-11-26",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1026.56, "close": 1050.3, "high": 1052.88, "low": 1026.09, "changeRate": 2.45},
+          {"ticker": "^NDX", "open": 1372.21, "close": 1338.02, "high": 1374.5, "low": 1333.54, "changeRate": -2.64},
+          {"ticker": "GLD", "open": 101.74, "close": 102.16, "high": 102.26, "low": 101.53, "changeRate": 0.63}
+          ], "roundAsset": 9478027, "returnRate": -2.14
+        },
+        {
+          "round": 63,
+          "date": "2008-11-27",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1050.83, "close": 1033.18, "high": 1053.22, "low": 1031.56, "changeRate": -1.63},
+          {"ticker": "^NDX", "open": 1335.66, "close": 1379.36, "high": 1386.05, "low": 1332.96, "changeRate": 3.09},
+          {"ticker": "GLD", "open": 102.17, "close": 103.86, "high": 104.17, "low": 101.97, "changeRate": 1.66}
+          ], "roundAsset": 9434040, "returnRate": -2.59
+        },
+        {
+          "round": 64,
+          "date": "2008-11-28",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1031.75, "close": 1033.49, "high": 1037.4, "low": 1028.52, "changeRate": 0.03},
+          {"ticker": "^NDX", "open": 1382.95, "close": 1366.95, "high": 1384.36, "low": 1363.2, "changeRate": -0.9},
+          {"ticker": "GLD", "open": 104.13, "close": 102.66, "high": 104.27, "low": 102.44, "changeRate": -1.16}
+          ], "roundAsset": 9434837, "returnRate": -2.58
+        },
+        {
+          "round": 65,
+          "date": "2008-12-01",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1030.8, "close": 1005.48, "high": 1031.62, "low": 1002.71, "changeRate": -2.71},
+          {"ticker": "^NDX", "open": 1367.66, "close": 1412.06, "high": 1412.72, "low": 1360.87, "changeRate": 3.3},
+          {"ticker": "GLD", "open": 102.91, "close": 103.42, "high": 103.56, "low": 102.87, "changeRate": 0.74}
+          ], "roundAsset": 9362870, "returnRate": -3.33
+        },
+        {
+          "round": 66,
+          "date": "2008-12-02",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1005.57, "close": 1024.68, "high": 1026.08, "low": 1001.37, "changeRate": 1.91},
+          {"ticker": "^NDX", "open": 1418.84, "close": 1408.39, "high": 1420.57, "low": 1404.51, "changeRate": -0.26},
+          {"ticker": "GLD", "open": 103.35, "close": 104.68, "high": 104.97, "low": 103.19, "changeRate": 1.22}
+          ], "roundAsset": 9412201, "returnRate": -2.82
+        },
+        {
+          "round": 67,
+          "date": "2008-12-03",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1027.65, "close": 1047.43, "high": 1049.6, "low": 1022.85, "changeRate": 2.22},
+          {"ticker": "^NDX", "open": 1408.5, "close": 1443.32, "high": 1449.24, "low": 1406.51, "changeRate": 2.48},
+          {"ticker": "GLD", "open": 104.55, "close": 103.88, "high": 104.73, "low": 103.57, "changeRate": -0.76}
+          ], "roundAsset": 9470653, "returnRate": -2.21
+        },
+        {
+          "round": 68,
+          "date": "2008-12-04",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1045.81, "close": 1044.08, "high": 1048.7, "low": 1041.24, "changeRate": -0.32},
+          {"ticker": "^NDX", "open": 1442.68, "close": 1401.61, "high": 1445.0, "low": 1400.29, "changeRate": -2.89},
+          {"ticker": "GLD", "open": 104.0, "close": 104.32, "high": 104.5, "low": 103.93, "changeRate": 0.42}
+          ], "roundAsset": 9462046, "returnRate": -2.3
+        },
+        {
+          "round": 69,
+          "date": "2008-12-05",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1046.22, "close": 1060.16, "high": 1064.46, "low": 1044.2, "changeRate": 1.54},
+          {"ticker": "^NDX", "open": 1403.9, "close": 1350.17, "high": 1409.66, "low": 1343.55, "changeRate": -3.67},
+          {"ticker": "GLD", "open": 104.32, "close": 105.73, "high": 105.74, "low": 104.16, "changeRate": 1.35}
+          ], "roundAsset": 9503361, "returnRate": -1.87
+        },
+        {
+          "round": 70,
+          "date": "2008-12-08",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1059.53, "close": 1063.76, "high": 1066.56, "low": 1057.11, "changeRate": 0.34},
+          {"ticker": "^NDX", "open": 1353.17, "close": 1384.19, "high": 1387.03, "low": 1348.74, "changeRate": 2.52},
+          {"ticker": "GLD", "open": 105.51, "close": 107.77, "high": 107.92, "low": 105.2, "changeRate": 1.93}
+          ], "roundAsset": 9512611, "returnRate": -1.78
+        },
+        {
+          "round": 71,
+          "date": "2008-12-09",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1067.5, "close": 1049.93, "high": 1072.05, "low": 1045.42, "changeRate": -1.3},
+          {"ticker": "^NDX", "open": 1382.53, "close": 1400.8, "high": 1403.02, "low": 1377.56, "changeRate": 1.2},
+          {"ticker": "GLD", "open": 107.94, "close": 108.76, "high": 109.04, "low": 107.93, "changeRate": 0.92}
+          ], "roundAsset": 9477077, "returnRate": -2.15
+        },
+        {
+          "round": 72,
+          "date": "2008-12-10",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1055.15, "close": 1017.8, "high": 1059.09, "low": 1015.59, "changeRate": -3.06},
+          {"ticker": "^NDX", "open": 1395.17, "close": 1411.03, "high": 1415.5, "low": 1389.08, "changeRate": 0.73},
+          {"ticker": "GLD", "open": 108.72, "close": 111.09, "high": 111.32, "low": 108.43, "changeRate": 2.14}
+          ], "roundAsset": 9394524, "returnRate": -3.0
+        },
+        {
+          "round": 73,
+          "date": "2008-12-11",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1016.53, "close": 985.23, "high": 1017.27, "low": 982.61, "changeRate": -3.2},
+          {"ticker": "^NDX", "open": 1411.96, "close": 1438.83, "high": 1444.53, "low": 1410.76, "changeRate": 1.97},
+          {"ticker": "GLD", "open": 110.81, "close": 110.33, "high": 111.1, "low": 110.12, "changeRate": -0.68}
+          ], "roundAsset": 9310841, "returnRate": -3.86
+        },
+        {
+          "round": 74,
+          "date": "2008-12-12",
+          "priceData": [
+          {"ticker": "^SPX", "open": 984.85, "close": 966.22, "high": 986.1, "low": 964.99, "changeRate": -1.93},
+          {"ticker": "^NDX", "open": 1431.77, "close": 1479.84, "high": 1485.79, "low": 1425.32, "changeRate": 2.85},
+          {"ticker": "GLD", "open": 110.45, "close": 108.83, "high": 110.5, "low": 108.69, "changeRate": -1.36}
+          ], "roundAsset": 9261998, "returnRate": -4.37
+        }
+      ]
+    }
+  };
+
+  // POST /game/round/action — 75라운드 카드 선택 (round 75~100)
+  static Map<String, dynamic> actionResult4 = {
+    "success": true,
+    "message": "OK",
+    "data": {
+      "selectedCard": "금 피난처",
+      "nextEventRound": null,
+      "nextCardOptions": [],
+      "rounds": [
+        {
+          "round": 75,
+          "date": "2008-12-15",
+          "priceData": [
+          {"ticker": "^SPX", "open": 965.49, "close": 954.14, "high": 966.7, "low": 950.11, "changeRate": -1.25},
+          {"ticker": "^NDX", "open": 1475.39, "close": 1485.91, "high": 1488.77, "low": 1471.83, "changeRate": 0.41},
+          {"ticker": "GLD", "open": 108.66, "close": 109.79, "high": 109.98, "low": 108.47, "changeRate": 0.88}
+          ], "roundAsset": 9261998, "returnRate": 0.0
+        },
+        {
+          "round": 76,
+          "date": "2008-12-16",
+          "priceData": [
+          {"ticker": "^SPX", "open": 955.65, "close": 982.29, "high": 983.64, "low": 952.95, "changeRate": 2.95},
+          {"ticker": "^NDX", "open": 1488.67, "close": 1459.31, "high": 1494.21, "low": 1458.95, "changeRate": -1.79},
+          {"ticker": "GLD", "open": 109.86, "close": 112.42, "high": 112.59, "low": 109.56, "changeRate": 2.4}
+          ], "roundAsset": 9343975, "returnRate": 0.89
+        },
+        {
+          "round": 77,
+          "date": "2008-12-17",
+          "priceData": [
+          {"ticker": "^SPX", "open": 980.84, "close": 966.18, "high": 983.96, "low": 963.18, "changeRate": -1.64},
+          {"ticker": "^NDX", "open": 1461.9, "close": 1488.35, "high": 1493.71, "low": 1457.08, "changeRate": 1.99},
+          {"ticker": "GLD", "open": 112.65, "close": 113.24, "high": 113.45, "low": 112.34, "changeRate": 0.73}
+          ], "roundAsset": 9297060, "returnRate": 0.38
+        },
+        {
+          "round": 78,
+          "date": "2008-12-18",
+          "priceData": [
+          {"ticker": "^SPX", "open": 966.95, "close": 972.94, "high": 976.5, "low": 966.51, "changeRate": 0.7},
+          {"ticker": "^NDX", "open": 1485.3, "close": 1463.35, "high": 1490.85, "low": 1462.06, "changeRate": -1.68},
+          {"ticker": "GLD", "open": 112.99, "close": 113.22, "high": 113.4, "low": 112.66, "changeRate": -0.02}
+          ], "roundAsset": 9316746, "returnRate": 0.59
+        },
+        {
+          "round": 79,
+          "date": "2008-12-19",
+          "priceData": [
+          {"ticker": "^SPX", "open": 970.58, "close": 972.45, "high": 976.46, "low": 968.24, "changeRate": -0.05},
+          {"ticker": "^NDX", "open": 1467.83, "close": 1505.06, "high": 1510.68, "low": 1465.34, "changeRate": 2.85},
+          {"ticker": "GLD", "open": 112.96, "close": 115.19, "high": 115.52, "low": 112.91, "changeRate": 1.74}
+          ], "roundAsset": 9315319, "returnRate": 0.58
+        },
+        {
+          "round": 80,
+          "date": "2008-12-22",
+          "priceData": [
+          {"ticker": "^SPX", "open": 977.12, "close": 999.48, "high": 1004.31, "low": 973.19, "changeRate": 2.78},
+          {"ticker": "^NDX", "open": 1503.04, "close": 1541.93, "high": 1548.03, "low": 1502.94, "changeRate": 2.45},
+          {"ticker": "GLD", "open": 115.22, "close": 116.64, "high": 116.8, "low": 114.99, "changeRate": 1.26}
+          ], "roundAsset": 9394035, "returnRate": 1.43
+        },
+        {
+          "round": 81,
+          "date": "2008-12-23",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1003.88, "close": 1008.18, "high": 1008.73, "low": 1002.71, "changeRate": 0.87},
+          {"ticker": "^NDX", "open": 1534.61, "close": 1547.79, "high": 1554.63, "low": 1530.3, "changeRate": 0.38},
+          {"ticker": "GLD", "open": 116.93, "close": 118.62, "high": 118.7, "low": 116.91, "changeRate": 1.7}
+          ], "roundAsset": 9419371, "returnRate": 1.7
+        },
+        {
+          "round": 82,
+          "date": "2008-12-24",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1007.26, "close": 1026.93, "high": 1027.65, "low": 1002.49, "changeRate": 1.86},
+          {"ticker": "^NDX", "open": 1544.76, "close": 1591.44, "high": 1595.36, "low": 1544.01, "changeRate": 2.82},
+          {"ticker": "GLD", "open": 118.9, "close": 117.86, "high": 118.95, "low": 117.7, "changeRate": -0.64}
+          ], "roundAsset": 9473973, "returnRate": 2.29
+        },
+        {
+          "round": 83,
+          "date": "2008-12-25",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1026.1, "close": 1035.76, "high": 1039.6, "low": 1025.31, "changeRate": 0.86},
+          {"ticker": "^NDX", "open": 1590.09, "close": 1616.43, "high": 1617.23, "low": 1586.2, "changeRate": 1.57},
+          {"ticker": "GLD", "open": 117.8, "close": 120.52, "high": 120.86, "low": 117.79, "changeRate": 2.26}
+          ], "roundAsset": 9499688, "returnRate": 2.57
+        },
+        {
+          "round": 84,
+          "date": "2008-12-26",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1039.44, "close": 1024.47, "high": 1039.96, "low": 1020.96, "changeRate": -1.09},
+          {"ticker": "^NDX", "open": 1617.15, "close": 1605.6, "high": 1625.06, "low": 1602.72, "changeRate": -0.67},
+          {"ticker": "GLD", "open": 120.45, "close": 123.27, "high": 123.34, "low": 120.41, "changeRate": 2.28}
+          ], "roundAsset": 9466810, "returnRate": 2.21
+        },
+        {
+          "round": 85,
+          "date": "2008-12-29",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1025.92, "close": 1045.06, "high": 1048.18, "low": 1025.81, "changeRate": 2.01},
+          {"ticker": "^NDX", "open": 1610.2, "close": 1596.13, "high": 1612.16, "low": 1595.13, "changeRate": -0.59},
+          {"ticker": "GLD", "open": 123.32, "close": 124.48, "high": 124.51, "low": 123.04, "changeRate": 0.98}
+          ], "roundAsset": 9526771, "returnRate": 2.86
+        },
+        {
+          "round": 86,
+          "date": "2008-12-30",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1043.27, "close": 1022.59, "high": 1044.04, "low": 1017.99, "changeRate": -2.15},
+          {"ticker": "^NDX", "open": 1588.19, "close": 1558.14, "high": 1595.01, "low": 1557.01, "changeRate": -2.38},
+          {"ticker": "GLD", "open": 124.2, "close": 126.86, "high": 126.96, "low": 124.13, "changeRate": 1.91}
+          ], "roundAsset": 9461335, "returnRate": 2.15
+        },
+        {
+          "round": 87,
+          "date": "2008-12-31",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1025.56, "close": 1030.77, "high": 1032.0, "low": 1023.9, "changeRate": 0.8},
+          {"ticker": "^NDX", "open": 1553.06, "close": 1498.77, "high": 1553.47, "low": 1493.21, "changeRate": -3.81},
+          {"ticker": "GLD", "open": 126.88, "close": 124.41, "high": 127.16, "low": 124.23, "changeRate": -1.93}
+          ], "roundAsset": 9485156, "returnRate": 2.41
+        },
+        {
+          "round": 88,
+          "date": "2009-01-01",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1030.81, "close": 1046.85, "high": 1051.8, "low": 1030.59, "changeRate": 1.56},
+          {"ticker": "^NDX", "open": 1503.01, "close": 1496.52, "high": 1509.53, "low": 1492.62, "changeRate": -0.15},
+          {"ticker": "GLD", "open": 124.38, "close": 122.53, "high": 124.74, "low": 122.51, "changeRate": -1.51}
+          ], "roundAsset": 9531983, "returnRate": 2.91
+        },
+        {
+          "round": 89,
+          "date": "2009-01-02",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1046.75, "close": 1042.77, "high": 1051.51, "low": 1042.39, "changeRate": -0.39},
+          {"ticker": "^NDX", "open": 1490.25, "close": 1481.7, "high": 1494.78, "low": 1481.21, "changeRate": -0.99},
+          {"ticker": "GLD", "open": 122.36, "close": 123.87, "high": 124.11, "low": 122.16, "changeRate": 1.09}
+          ], "roundAsset": 9520102, "returnRate": 2.79
+        },
+        {
+          "round": 90,
+          "date": "2009-01-05",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1042.29, "close": 1028.28, "high": 1045.45, "low": 1027.77, "changeRate": -1.39},
+          {"ticker": "^NDX", "open": 1484.69, "close": 1532.97, "high": 1539.51, "low": 1479.86, "changeRate": 3.46},
+          {"ticker": "GLD", "open": 124.07, "close": 124.35, "high": 124.62, "low": 123.99, "changeRate": 0.39}
+          ], "roundAsset": 9477905, "returnRate": 2.33
+        },
+        {
+          "round": 91,
+          "date": "2009-01-06",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1027.8, "close": 1022.52, "high": 1029.94, "low": 1022.03, "changeRate": -0.56},
+          {"ticker": "^NDX", "open": 1531.85, "close": 1497.86, "high": 1536.94, "low": 1495.06, "changeRate": -2.29},
+          {"ticker": "GLD", "open": 124.09, "close": 123.77, "high": 124.43, "low": 123.75, "changeRate": -0.47}
+          ], "roundAsset": 9461131, "returnRate": 2.15
+        },
+        {
+          "round": 92,
+          "date": "2009-01-07",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1024.96, "close": 1042.05, "high": 1046.28, "low": 1022.11, "changeRate": 1.91},
+          {"ticker": "^NDX", "open": 1499.16, "close": 1448.43, "high": 1503.37, "low": 1446.04, "changeRate": -3.3},
+          {"ticker": "GLD", "open": 123.49, "close": 121.83, "high": 123.62, "low": 121.59, "changeRate": -1.57}
+          ], "roundAsset": 9518005, "returnRate": 2.76
+        },
+        {
+          "round": 93,
+          "date": "2009-01-08",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1046.93, "close": 1056.43, "high": 1059.6, "low": 1045.09, "changeRate": 1.38},
+          {"ticker": "^NDX", "open": 1449.56, "close": 1484.79, "high": 1486.37, "low": 1444.8, "changeRate": 2.51},
+          {"ticker": "GLD", "open": 121.63, "close": 123.34, "high": 123.38, "low": 121.32, "changeRate": 1.24}
+          ], "roundAsset": 9559882, "returnRate": 3.22
+        },
+        {
+          "round": 94,
+          "date": "2009-01-09",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1059.68, "close": 1044.7, "high": 1064.16, "low": 1039.61, "changeRate": -1.11},
+          {"ticker": "^NDX", "open": 1489.52, "close": 1510.33, "high": 1514.96, "low": 1484.73, "changeRate": 1.72},
+          {"ticker": "GLD", "open": 122.99, "close": 124.06, "high": 124.41, "low": 122.68, "changeRate": 0.58}
+          ], "roundAsset": 9525722, "returnRate": 2.85
+        },
+        {
+          "round": 95,
+          "date": "2009-01-12",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1042.7, "close": 1026.31, "high": 1044.47, "low": 1026.28, "changeRate": -1.76},
+          {"ticker": "^NDX", "open": 1515.92, "close": 1470.31, "high": 1520.21, "low": 1467.36, "changeRate": -2.65},
+          {"ticker": "GLD", "open": 123.79, "close": 125.5, "high": 125.74, "low": 123.78, "changeRate": 1.16}
+          ], "roundAsset": 9472168, "returnRate": 2.27
+        },
+        {
+          "round": 96,
+          "date": "2009-01-13",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1024.68, "close": 1040.17, "high": 1042.09, "low": 1020.98, "changeRate": 1.35},
+          {"ticker": "^NDX", "open": 1474.38, "close": 1435.17, "high": 1478.56, "low": 1434.56, "changeRate": -2.39},
+          {"ticker": "GLD", "open": 125.16, "close": 125.36, "high": 125.42, "low": 124.93, "changeRate": -0.11}
+          ], "roundAsset": 9512530, "returnRate": 2.7
+        },
+        {
+          "round": 97,
+          "date": "2009-01-14",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1040.02, "close": 1049.32, "high": 1051.64, "low": 1038.6, "changeRate": 0.88},
+          {"ticker": "^NDX", "open": 1438.83, "close": 1407.04, "high": 1439.65, "low": 1404.02, "changeRate": -1.96},
+          {"ticker": "GLD", "open": 125.2, "close": 126.59, "high": 126.85, "low": 125.02, "changeRate": 0.98}
+          ], "roundAsset": 9539176, "returnRate": 2.99
+        },
+        {
+          "round": 98,
+          "date": "2009-01-15",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1050.36, "close": 1058.13, "high": 1058.17, "low": 1048.78, "changeRate": 0.84},
+          {"ticker": "^NDX", "open": 1402.98, "close": 1355.54, "high": 1403.94, "low": 1353.81, "changeRate": -3.66},
+          {"ticker": "GLD", "open": 126.46, "close": 126.31, "high": 126.46, "low": 126.03, "changeRate": -0.22}
+          ], "roundAsset": 9564833, "returnRate": 3.27
+        },
+        {
+          "round": 99,
+          "date": "2009-01-16",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1058.13, "close": 1033.16, "high": 1062.54, "low": 1029.0, "changeRate": -2.36},
+          {"ticker": "^NDX", "open": 1349.74, "close": 1339.95, "high": 1355.56, "low": 1339.67, "changeRate": -1.15},
+          {"ticker": "GLD", "open": 125.95, "close": 127.79, "high": 128.14, "low": 125.62, "changeRate": 1.17}
+          ], "roundAsset": 9492116, "returnRate": 2.48
+        },
+        {
+          "round": 100,
+          "date": "2009-01-19",
+          "priceData": [
+          {"ticker": "^SPX", "open": 1032.31, "close": 1035.64, "high": 1036.24, "low": 1032.2, "changeRate": 0.24},
+          {"ticker": "^NDX", "open": 1337.6, "close": 1343.97, "high": 1349.35, "low": 1333.47, "changeRate": 0.3},
+          {"ticker": "GLD", "open": 128.04, "close": 129.31, "high": 129.67, "low": 128.01, "changeRate": 1.19}
+          ], "roundAsset": 9499338, "returnRate": 2.56
+        }
+      ]
+    }
+  };
+
+  // 현재 라운드 기준으로 맞는 actionResult 반환
+  static Map<String, dynamic> getActionResult(int roundIndex) {
+    if (roundIndex < 25)  return actionResult1;
+    if (roundIndex < 50)  return actionResult2;
+    if (roundIndex < 75)  return actionResult3;
+    return actionResult4;
+  }
 }

--- a/frontEnd/lib/widgets/stock_chart.dart
+++ b/frontEnd/lib/widgets/stock_chart.dart
@@ -3,190 +3,221 @@ import 'package:flutter/material.dart';
 import '../models/round_data.dart';
 import '../models/price_data.dart';
 
+// 종목별 고정 색상
+const Map<String, Color> tickerColors = {
+  '^SPX': Color(0xFF1971C2),  // 파랑
+  '^NDX': Color(0xFF7048E8),  // 보라
+  'GLD':  Color(0xFFE67700),  // 노랑
+};
+
+Color tickerColor(String ticker) =>
+    tickerColors[ticker] ?? const Color(0xFF6B7684);
+
 class StockChart extends StatelessWidget {
   final List<RoundData> rounds;
-  final String ticker;
 
   const StockChart({
     super.key,
     required this.rounds,
-    required this.ticker,
   });
 
-  // ticker에 해당하는 종가(close) 리스트 추출
-  List<PriceData> get _prices {
-    return rounds
-        .map((r) => r.getPrice(ticker))
-        .whereType<PriceData>()
-        .toList();
+  // rounds에 존재하는 ticker 목록 추출
+  List<String> get _tickers {
+    if (rounds.isEmpty) return [];
+    final Set<String> seen = {};
+    final List<String> result = [];
+    for (final r in rounds) {
+      for (final p in r.priceData) {
+        if (seen.add(p.ticker)) result.add(p.ticker);
+      }
+    }
+    return result;
   }
 
-  // fl_chart용 FlSpot 리스트 변환 (x: 인덱스, y: 종가)
-  List<FlSpot> get _spots {
-    return List.generate(_prices.length, (i) {
-      return FlSpot(i.toDouble(), _prices[i].close);
-    });
+  // 특정 ticker의 FlSpot 리스트
+  List<FlSpot> _spots(String ticker) {
+    final List<FlSpot> spots = [];
+    for (int i = 0; i < rounds.length; i++) {
+      final price = rounds[i].getPrice(ticker);
+      if (price != null) {
+        spots.add(FlSpot(i.toDouble(), price.close));
+      }
+    }
+    return spots;
   }
 
+  // Y축 범위
   double get _minY {
-    if (_prices.isEmpty) return 0;
-    final min = _prices.map((p) => p.close).reduce((a, b) => a < b ? a : b);
-    return min * 0.98; // 아래 여백 2%
+    double min = double.infinity;
+    for (final r in rounds) {
+      for (final p in r.priceData) {
+        if (p.close < min) min = p.close;
+      }
+    }
+    return min == double.infinity ? 0 : min * 0.97;
   }
 
   double get _maxY {
-    if (_prices.isEmpty) return 100;
-    final max = _prices.map((p) => p.close).reduce((a, b) => a > b ? a : b);
-    return max * 1.02; // 위 여백 2%
-  }
-
-  // 상승/하락 색상 (첫날 대비 현재)
-  Color get _lineColor {
-    if (_prices.length < 2) return const Color(0xFF6B7684);
-    return _prices.last.close >= _prices.first.close
-        ? const Color(0xFFE03131) // 상승 빨강
-        : const Color(0xFF1971C2); // 하락 파랑
+    double max = double.negativeInfinity;
+    for (final r in rounds) {
+      for (final p in r.priceData) {
+        if (p.close > max) max = p.close;
+      }
+    }
+    return max == double.negativeInfinity ? 100 : max * 1.03;
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_prices.isEmpty) {
+    if (rounds.isEmpty) {
       return const Center(
-        child: Text(
-          '데이터 없음',
-          style: TextStyle(color: Color(0xFF6B7684)),
-        ),
+        child: Text('데이터 없음', style: TextStyle(color: Color(0xFF6B7684))),
       );
     }
 
-    return LineChart(
-      LineChartData(
-        minY: _minY,
-        maxY: _maxY,
-        minX: 0,
-        maxX: (_prices.length - 1).toDouble(),
+    final tickers = _tickers;
 
-        // 선 데이터
-        lineBarsData: [
-          LineChartBarData(
-            spots: _spots,
-            color: _lineColor,
-            barWidth: 2,
-            isCurved: true, // 부드러운 곡선
-            curveSmoothness: 0.3,
-            dotData: FlDotData(
-              show: true,
-              getDotPainter: (spot, percent, bar, index) {
-                // 마지막 점만 강조
-                final isLast = index == _spots.length - 1;
-                return FlDotCirclePainter(
-                  radius: isLast ? 5 : 3,
-                  color: _lineColor,
-                  strokeWidth: isLast ? 2 : 0,
-                  strokeColor: Colors.white,
+    return Column(
+      children: [
+        // 종목 범례 (여러 종목일 때만 표시)
+        if (tickers.length > 1)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: tickers.map((t) => Padding(
+                padding: const EdgeInsets.only(left: 12),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 12, height: 3,
+                      color: tickerColor(t),
+                    ),
+                    const SizedBox(width: 4),
+                    Text(t, style: const TextStyle(
+                      fontSize: 10, color: Color(0xFF6B7684),
+                    )),
+                  ],
+                ),
+              )).toList(),
+            ),
+          ),
+
+        // 차트
+        Expanded(
+          child: LineChart(
+            LineChartData(
+              minY: _minY,
+              maxY: _maxY,
+              minX: 0,
+              maxX: (rounds.length - 1).toDouble(),
+
+              lineBarsData: tickers.map((ticker) {
+                final spots = _spots(ticker);
+                final color = tickerColor(ticker);
+                final isLast = ticker == tickers.last;
+                return LineChartBarData(
+                  spots: spots,
+                  color: color,
+                  barWidth: 2,
+                  isCurved: true,
+                  curveSmoothness: 0.3,
+                  dotData: FlDotData(
+                    show: true,
+                    getDotPainter: (spot, _, __, index) {
+                      final isLastDot = index == spots.length - 1;
+                      return FlDotCirclePainter(
+                        radius: isLastDot ? 4 : 0,
+                        color: color,
+                        strokeWidth: isLastDot ? 2 : 0,
+                        strokeColor: Colors.white,
+                      );
+                    },
+                  ),
+                  belowBarData: BarAreaData(
+                    show: isLast,
+                    color: color.withValues(alpha: 0.06),
+                  ),
                 );
-              },
-            ),
-            // 선 아래 그라데이션
-            belowBarData: BarAreaData(
-              show: true,
-              color: _lineColor.withValues(alpha: 0.08),
-            ),
-          ),
-        ],
+              }).toList(),
 
-        // 격자선
-        gridData: FlGridData(
-          show: true,
-          drawVerticalLine: false,
-          horizontalInterval: (_maxY - _minY) / 4,
-          getDrawingHorizontalLine: (_) => const FlLine(
-            color: Color(0xFFEEEEEE),
-            strokeWidth: 1,
-          ),
-        ),
+              gridData: FlGridData(
+                show: true,
+                drawVerticalLine: false,
+                horizontalInterval: (_maxY - _minY) / 4,
+                getDrawingHorizontalLine: (_) => const FlLine(
+                  color: Color(0xFFEEEEEE), strokeWidth: 1,
+                ),
+              ),
 
-        // 테두리
-        borderData: FlBorderData(
-          show: true,
-          border: const Border(
-            bottom: BorderSide(color: Color(0xFFEEEEEE), width: 1),
-            left: BorderSide(color: Color(0xFFEEEEEE), width: 1),
-          ),
-        ),
+              borderData: FlBorderData(
+                show: true,
+                border: const Border(
+                  bottom: BorderSide(color: Color(0xFFEEEEEE), width: 1),
+                  left:   BorderSide(color: Color(0xFFEEEEEE), width: 1),
+                ),
+              ),
 
-        // 축 레이블
-        titlesData: FlTitlesData(
-          bottomTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              reservedSize: 28,
-              interval: 1,
-              getTitlesWidget: (value, meta) {
-                final index = value.toInt();
-                if (index < 0 || index >= rounds.length) {
-                  return const SizedBox.shrink();
-                }
-                final date = rounds[index].date;
-                final parts = date.split('-');
-                final label =
-                    parts.length >= 3 ? '${parts[1]}/${parts[2]}' : date;
-                return Padding(
-                  padding: const EdgeInsets.only(top: 6),
-                  child: Text(
-                    label,
-                    style: const TextStyle(
-                      fontSize: 10,
-                      color: Color(0xFF6B7684),
+              titlesData: FlTitlesData(
+                bottomTitles: AxisTitles(
+                  sideTitles: SideTitles(
+                    showTitles: true,
+                    reservedSize: 24,
+                    interval: (rounds.length / 5).ceilToDouble(),
+                    getTitlesWidget: (value, _) {
+                      final index = value.toInt();
+                      if (index < 0 || index >= rounds.length) {
+                        return const SizedBox.shrink();
+                      }
+                      final date = rounds[index].date;
+                      final parts = date.split('-');
+                      final label = parts.length >= 3
+                          ? '${parts[1]}/${parts[2]}'
+                          : date;
+                      return Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(label, style: const TextStyle(
+                          fontSize: 9, color: Color(0xFF6B7684),
+                        )),
+                      );
+                    },
+                  ),
+                ),
+                leftTitles: AxisTitles(
+                  sideTitles: SideTitles(
+                    showTitles: true,
+                    reservedSize: 52,
+                    getTitlesWidget: (value, _) => Text(
+                      value.toStringAsFixed(0),
+                      style: const TextStyle(
+                        fontSize: 9, color: Color(0xFF6B7684),
+                      ),
                     ),
                   ),
-                );
-              },
-            ),
-          ),
-          leftTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              reservedSize: 56,
-              getTitlesWidget: (value, meta) {
-                return Text(
-                  value.toStringAsFixed(0),
-                  style: const TextStyle(
-                    fontSize: 10,
-                    color: Color(0xFF6B7684),
-                  ),
-                );
-              },
-            ),
-          ),
-          topTitles: const AxisTitles(
-            sideTitles: SideTitles(showTitles: false),
-          ),
-          rightTitles: const AxisTitles(
-            sideTitles: SideTitles(showTitles: false),
-          ),
-        ),
+                ),
+                topTitles:   const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              ),
 
-        // 터치 툴팁 (점 누르면 값 표시)
-        lineTouchData: LineTouchData(
-          touchTooltipData: LineTouchTooltipData(
-            getTooltipItems: (touchedSpots) {
-              return touchedSpots.map((spot) {
-                final index = spot.x.toInt();
-                final date = index < rounds.length ? rounds[index].date : '';
-                return LineTooltipItem(
-                  '$date\n${spot.y.toStringAsFixed(2)}',
-                  const TextStyle(
-                    color: Colors.white,
-                    fontSize: 11,
-                    fontWeight: FontWeight.w500,
-                  ),
-                );
-              }).toList();
-            },
+              lineTouchData: LineTouchData(
+                touchTooltipData: LineTouchTooltipData(
+                  getTooltipItems: (spots) => spots.map((spot) {
+                    final index = spot.x.toInt();
+                    final date = index < rounds.length ? rounds[index].date : '';
+                    return LineTooltipItem(
+                      '$date\n${spot.y.toStringAsFixed(2)}',
+                     const TextStyle(
+                        color: Colors.white, fontSize: 10,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    );
+                  }).toList(),
+                ),
+              ),
+            ),
           ),
         ),
-      ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈> #16 

## 📝 작업 내용

### 🗂️ 폴더 구조
```
lib/
  models/
    card_info.dart       # 새로 추가 - 카드 6개 정의
    game_session.dart    # 수정 - firstCardOptions, cardSelectRounds 추가
    action_result.dart   # 수정 - nextCardOptions 추가
    round_data.dart      # 수정 - roundAsset, returnRate nullable 추가

  services/
    mock_data.dart       # 수정 - 서버 구조에 맞게 재생성
                         #        /game/start → rounds 1개
                         #        /game/action → 구간별 24/25개

  screens/
    game_screen.dart     # 수정 - 카드 UI / 자동재생 / 멀티차트 / 버그 수정

  widgets/
    stock_chart.dart     # 수정 - 멀티 종목 지원 (SPX/NDX/GLD)
```

---

### ⚙️ API 변경사항

**POST /game/start 응답 추가**
```json
{
  "cardSelectRounds": [1, 25, 50, 75],
  "firstCardOptions": [1, 4, 6]
}
```

**POST /game/round/action 응답 추가**
```json
{
  "nextCardOptions": [3, 5, 2]
}
```

**rounds 구조 변경**
```
기존: /game/start에서 전체 rounds 다 받음
변경: /game/start → rounds 1개만 (1라운드)
      /game/action → 카드 선택 시점 ~ 다음 증강 직전까지
      (ex. 1라운드 선택 → rounds 1~24 / 25라운드 선택 → rounds 25~49)
```

---

### 🖥️ 구현된 기능

**카드 선택 UI**
- `cardSelectRounds` 기반으로 해당 라운드 도달 시 카드 3개 동적 표시
- `firstCardOptions` → 1라운드 카드 선택지
- `nextCardOptions` → 이후 카드 선택지 (카드 선택 이력 반영)
- 이모티콘 + 이름 + 설명 포함

**라운드 진행**
- 수동: 다음 라운드 버튼으로 1라운드씩 진행
- 자동: 1초에 1라운드씩 자동 진행 (▶/⏸ 토글)
- 다음 카드 선택 라운드 도달 시 자동 멈춤

**멀티 종목 차트**
- SPX(파랑) / NDX(보라) / GLD(노랑)
- 카드 선택 후 priceData에 종목 추가되면 자동으로 선 추가
- 종목 범례 자동 표시

---

### 🔥 트러블슈팅

**1. RangeError: Index out of range**
```
원인: _isLastRound가 totalRounds(100) 기준으로 비교
      서버는 rounds를 1개만 주는데
      _currentRoundIndex가 올라가면서 범위 초과

해결: totalRounds → rounds.length 기준으로 변경
      clamp로 인덱스 범위 보호 추가
```

**2. 카드 선택 후 바로 게임 종료 표시**
```
원인: rounds.length = 1이라
      _isLastRound = 0 >= 0 → true

해결: _isLastRound 조건 추가
      - 카드 선택 전 → false
      - 다음 라운드가 카드 선택 라운드 → false
      - rounds 다 소진됐을 때만 → true
```

**3. 25라운드 카드 선택 시 round: 24 전송**
```
원인: _currentRound.round 사용
      _currentRoundIndex = 24인데
      rounds.length = 24라서 clamp(24, 0, 23) = 23
      rounds[23].round = 24 → 24 전송

해결: _currentRound.round → _currentRound1 (_currentRoundIndex + 1)
      배열과 무관하게 직접 계산
```

**4. mock 데이터와 서버 구조 불일치**
```
원인: mock은 rounds 25개 / 서버는 24개
      카드 선택 라운드 타이밍이 달랐음

해결: mock 데이터를 서버와 동일한 구조로 재생성
      action1: 1~24 (24개)
      action2: 25~49 (25개)
      action3: 50~74 (25개)
      action4: 75~100 (26개)
```

---

### ✅ To-do

- [x] CardInfo 모델 추가 (카드 6개 정의)
- [x] GameSession firstCardOptions / cardSelectRounds 추가
- [x] ActionResult nextCardOptions 추가
- [x] Mock 데이터 서버 구조에 맞게 재생성 (100라운드)
- [x] StockChart 멀티 종목 지원
- [x] GameScreen 카드 선택 UI (3개 선택지 + 이모티콘)
- [x] GameScreen 자동/수동 라운드 진행
- [x] RangeError 버그 수정
- [x] _isLastRound 조건 수정
- [x] round 번호 전송 오류 수정 (_currentRound1 사용)
- [ ] 실제 API 연결 및 fromJson 키 이름 검증
- [ ] 게임 종료 화면 구현 (ResultScreen)
- [ ] 카드 선택 애니메이션