### PR TITLE
[Feature] 카드 계산 로직 고도화

### DIFF
--- a/backend/src/main/java/com/capstone/survival/entity/GameSession.java
+++ b/backend/src/main/java/com/capstone/survival/entity/GameSession.java
@@ -29,8 +29,11 @@ public class GameSession {
     // 기존 필드들 아래에 추가
     private Long cash;              // 현재 현금
     private Double spxShares;       // 보유 SPX 수량
-    private Double ndxShares;      // ← 새로 추가
-    private Double xauusdShares;   // ← 새로 추가
+    private Double ndxShares;
+    private Double xauusdShares;
+    private Double usoShares;
+    private Double aaplShares;
+    private Double tltShares;
     private Integer currentRound;   // 현재 라운드
     private String appliedCards;    // 적용된 카드 목록 "1,2"
 
@@ -54,6 +57,9 @@ public class GameSession {
         this.spxShares = 0.0;
         this.ndxShares = 0.0;
         this.xauusdShares = 0.0;
+        this.usoShares = 0.0;
+        this.aaplShares = 0.0;
+        this.tltShares = 0.0;
         this.currentRound = 1;
         this.appliedCards = "";
         this.triggerCount = "";
@@ -61,12 +67,17 @@ public class GameSession {
 
     // 상태 업데이트 메서드 추가
     public void update(Long cash, Double spxShares, Double ndxShares,
-                       Double xauusdShares, Integer currentRound,
+                       Double xauusdShares, Double usoShares,
+                       Double aaplShares, Double tltShares,
+                       Integer currentRound,
                        String appliedCards, String triggerCount) {
         this.cash = cash;
         this.spxShares = spxShares;
         this.ndxShares = ndxShares;
         this.xauusdShares = xauusdShares;
+        this.usoShares = usoShares;
+        this.aaplShares = aaplShares;
+        this.tltShares = tltShares;
         this.currentRound = currentRound;
         this.appliedCards = appliedCards;
         this.triggerCount = triggerCount;

--- a/backend/src/main/java/com/capstone/survival/service/GameService.java
+++ b/backend/src/main/java/com/capstone/survival/service/GameService.java
@@ -25,7 +25,7 @@ public class GameService {
     private final CardRepository cardRepository;
 
     private static final List<Integer> CARD_SELECT_ROUNDS = List.of(1, 25, 50, 75);
-    private static final List<Integer> ALL_CARD_IDS = List.of(1, 2, 3, 4, 5, 6);
+    private static final List<Integer> ALL_CARD_IDS = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
 
     // =============================================
     // 게임 시작
@@ -108,6 +108,9 @@ public class GameService {
         double spxShares = session.getSpxShares();
         double ndxShares = session.getNdxShares();
         double xauusdShares = session.getXauusdShares();
+        double usoShares = session.getUsoShares();
+        double aaplShares = session.getAaplShares();
+        double tltShares = session.getTltShares();
         long cash = session.getCash();
 
         if ("BUY_ONCE".equals(card.getType())) {
@@ -115,9 +118,12 @@ public class GameService {
             double buyAmount = cash * card.getRatio();
             cash -= (long) buyAmount;
             double newShares = buyAmount / currentClose;
-            if ("^SPX".equals(card.getTicker())) spxShares += newShares;
-            else if ("^NDX".equals(card.getTicker())) ndxShares += newShares;
+            if ("^SPX".equals(card.getTicker()))      spxShares += newShares;
+            else if ("^NDX".equals(card.getTicker()))  ndxShares += newShares;
             else if ("XAUUSD".equals(card.getTicker())) xauusdShares += newShares;
+            else if ("USO".equals(card.getTicker()))   usoShares += newShares;
+            else if ("AAPL".equals(card.getTicker()))  aaplShares += newShares;
+            else if ("TLT".equals(card.getTicker()))   tltShares += newShares;
         }
 
         // 다음 증강 라운드
@@ -132,6 +138,7 @@ public class GameService {
         Map<String, Object> calcResult = calculateRounds(
                 session, round, endRound,
                 cash, spxShares, ndxShares, xauusdShares,
+                usoShares, aaplShares, tltShares,
                 appliedCardIds, session.getTriggerCount()
         );
 
@@ -140,11 +147,15 @@ public class GameService {
         double finalSpx = (double) calcResult.get("finalSpx");
         double finalNdx = (double) calcResult.get("finalNdx");
         double finalXauusd = (double) calcResult.get("finalXauusd");
+        double finalUso = (double) calcResult.get("finalUso");
+        double finalAapl = (double) calcResult.get("finalAapl");
+        double finalTlt = (double) calcResult.get("finalTlt");
         String finalTriggerCount = (String) calcResult.get("triggerCount");
 
         // 세션 업데이트
         session.update(
                 finalCash, finalSpx, finalNdx, finalXauusd,
+                finalUso, finalAapl, finalTlt,
                 endRound + 1, newAppliedCards, finalTriggerCount
         );
         sessionRepository.save(session);
@@ -169,15 +180,21 @@ public class GameService {
     private Map<String, Object> calculateRounds(
             GameSession session, int startRound, int endRound,
             long cash, double spxShares, double ndxShares, double xauusdShares,
+            double  usoShares, double aaplShares, double tltShares,
             List<Integer> appliedCardIds, String triggerCountStr) {
 
         // 주가 데이터 로드
         List<StockPrice> spxList = loadPriceList(session, "^SPX");
         List<StockPrice> ndxList = loadPriceList(session, "^NDX");
         List<StockPrice> xauusdList = loadPriceList(session, "XAUUSD");
+        List<StockPrice> usoList = loadPriceList(session, "USO");
+        List<StockPrice> aaplList = loadPriceList(session, "AAPL");
+        List<StockPrice> tltList = loadPriceList(session, "TLT");
+
 
         // 적용된 카드 목록
         List<Card> appliedCards = cardRepository.findAllById(appliedCardIds);
+        appliedCards.sort(Comparator.comparing(Card::getPriority));
 
         // 발동 횟수 파싱
         Map<Integer, Integer> triggerMap = parseTriggerCount(triggerCountStr);
@@ -187,75 +204,109 @@ public class GameService {
         for (int i = startRound - 1; i < endRound; i++) {
             if (i >= spxList.size()) break;
 
+            int roundNumber = i + 1;
+
             StockPrice spxCurrent = spxList.get(i);
             StockPrice spxPrev = i > 0 ? spxList.get(i - 1) : null;
             StockPrice ndxCurrent = i < ndxList.size() ? ndxList.get(i) : null;
-            StockPrice xauusdCurrent = i < xauusdList.size() ? xauusdList.get(i) : null;
             StockPrice ndxPrev = (i > 0 && i < ndxList.size()) ? ndxList.get(i - 1) : null;
+            StockPrice xauusdCurrent = i < xauusdList.size() ? xauusdList.get(i) : null;
+            StockPrice usoCurrent = i < usoList.size() ? usoList.get(i) : null;
+            StockPrice usoPrev = (i > 0 && i < usoList.size()) ? usoList.get(i - 1) : null;
+            StockPrice aaplCurrent = i < aaplList.size() ? aaplList.get(i) : null;
+            StockPrice aaplPrev = (i > 0 && i < aaplList.size()) ? aaplList.get(i - 1) : null;
+            StockPrice tltCurrent = i < tltList.size() ? tltList.get(i) : null;
 
             // 등락률 계산
             double spxChangeRate = calcChangeRate(spxPrev, spxCurrent);
             double ndxChangeRate = calcChangeRate(ndxPrev, ndxCurrent);
+            double aaplChangeRate = calcChangeRate(aaplPrev, aaplCurrent);
 
-            // 카드 발동 처리
-            // ticker별 매수 금액 합산
-            Map<String, Double> buyAmountByTicker = new LinkedHashMap<>();
-
-            for (Card card : appliedCards) {
-                if ("BUY_ONCE".equals(card.getType())) continue; // 이미 처리됨
-
-                boolean triggered = false;
-
-                if ("BUY_SPLIT".equals(card.getType())) {
-                    triggered = true;
-                } else if ("BUY_ON_CONDITION".equals(card.getType())) {
-                    triggered = checkCondition(card.getCondition(), spxChangeRate, ndxChangeRate);
-                }
-
-                if (!triggered) continue;
-
-                // maxTrigger 체크
-                if (card.getMaxTrigger() != null) {
-                    int count = triggerMap.getOrDefault(card.getId(), 0);
-                    if (count >= card.getMaxTrigger()) continue;
-                    triggerMap.put(card.getId(), count + 1);
-                }
-
-                // 매수 금액 합산 (같은 종목이면 더함)
-                double amount = cash * card.getRatio();
-                buyAmountByTicker.merge(card.getTicker(), amount, Double::sum);
-            }
-
-            // 실제 매수 실행
-            for (Map.Entry<String, Double> entry : buyAmountByTicker.entrySet()) {
-                String ticker = entry.getKey();
-                double amount = entry.getValue();
-                if (amount <= 0 || cash <= 0) continue;
-
-                amount = Math.min(amount, cash); // 현금 초과 방지
-                double price = getTickerPrice(ticker, spxCurrent, ndxCurrent, xauusdCurrent);
-                if (price <= 0) continue;
-
-                cash -= (long) amount;
-                double shares = amount / price;
-                if ("^SPX".equals(ticker)) spxShares += shares;
-                else if ("^NDX".equals(ticker)) ndxShares += shares;
-                else if ("XAUUSD".equals(ticker)) xauusdShares += shares;
-            }
-
-            // 자산 계산
+            // 자산 계산 (파산 방지 체크용)
             double spxValue = spxShares * spxCurrent.getClose();
             double ndxValue = ndxCurrent != null ? ndxShares * ndxCurrent.getClose() : 0;
             double xauusdValue = xauusdCurrent != null ? xauusdShares * xauusdCurrent.getClose() : 0;
-            long roundAsset = (long)(cash + spxValue + ndxValue + xauusdValue);
-            double returnRate = Math.round(
-                    (double)(roundAsset - session.getInitialAsset())
-                            / session.getInitialAsset() * 100 * 100.0) / 100.0;
+            double usoValue = usoCurrent != null ? usoShares * usoCurrent.getClose() : 0;
+            double aaplValue = aaplCurrent != null ? aaplShares * aaplCurrent.getClose() : 0;
+            double tltValue = tltCurrent != null ? tltShares * tltCurrent.getClose() : 0;
+            long totalAsset = cash + (long) (spxValue + ndxValue + xauusdValue + usoValue + aaplValue + tltValue);
+
+            List<Integer> triggeredCardIds = new ArrayList<>();
+
+            if (totalAsset > session.getInitialAsset() * 0.01) { // 파산 방지 체크
+
+                for (Card card : appliedCards) {
+                    if ("BUY_ONCE".equals(card.getType())) continue;
+
+                    boolean triggered = false;
+
+                    if ("BUY_SPLIT".equals(card.getType())) {
+                        triggered = true;
+                    } else if ("BUY_ON_CONDITION".equals(card.getType())) {
+                        triggered = checkCondition(card.getCondition(), spxChangeRate, ndxChangeRate, aaplChangeRate);
+                    } else if ("SELL_ON_CONDITION".equals(card.getType())) {
+                        triggered = checkCondition(card.getCondition(), spxChangeRate, ndxChangeRate, aaplChangeRate);
+                    } else if ("BUY_EVERY_N".equals(card.getType())) {
+                        triggered = (roundNumber % 5 == 0);
+                    }
+
+                    if (!triggered) continue;
+
+                    // maxTrigger 체크
+                    if (card.getMaxTrigger() != null) {
+                        int count = triggerMap.getOrDefault(card.getId(), 0);
+                        if (count >= card.getMaxTrigger()) continue;
+                        triggerMap.put(card.getId(), count + 1);
+                    }
+
+                    // 매도 카드 처리 (SELL_ON_CONDITION)
+                    if ("SELL_ON_CONDITION".equals(card.getType())) {
+                        double sellShares = 0;
+                        double sellPrice = 0;
+                        if ("^SPX".equals(card.getTicker())) {
+                            sellShares = spxShares * card.getRatio();
+                            sellPrice = spxCurrent.getClose();
+                            spxShares -= sellShares;
+                        }
+                        cash += (long) (sellShares * sellPrice);
+                        triggeredCardIds.add(card.getId());
+                        continue;
+                    }
+
+                    // 현금 부족 체크 (총자산의 5% 미만이면 매수 스킵)
+                    if (cash < totalAsset * 0.05) continue;
+
+                    // 매수 금액 계산 및 실행
+                    double amount = cash * card.getRatio();
+                    double price = getTickerPrice(card.getTicker(), spxCurrent, ndxCurrent, xauusdCurrent, usoCurrent, aaplCurrent, tltCurrent);
+                    if (price <= 0) continue;
+
+                    cash -= (long) amount;
+                    double shares = amount / price;
+                    if ("^SPX".equals(card.getTicker())) spxShares += shares;
+                    else if ("^NDX".equals(card.getTicker())) ndxShares += shares;
+                    else if ("XAUUSD".equals(card.getTicker())) xauusdShares += shares;
+                    else if ("USO".equals(card.getTicker())) usoShares += shares;
+                    else if ("AAPL".equals(card.getTicker())) aaplShares += shares;
+                    else if ("TLT".equals(card.getTicker())) tltShares += shares;
+
+                    triggeredCardIds.add(card.getId());
+                }
+            }
+
+            // 자산 재계산
+            spxValue = spxShares * spxCurrent.getClose();
+            ndxValue = ndxCurrent != null ? ndxShares * ndxCurrent.getClose() : 0;
+            xauusdValue = xauusdCurrent != null ? xauusdShares * xauusdCurrent.getClose() : 0;
+            usoValue = usoCurrent != null ? usoShares * usoCurrent.getClose() : 0;
+            aaplValue = aaplCurrent != null ? aaplShares * aaplCurrent.getClose() : 0;
+            tltValue = tltCurrent != null ? tltShares * tltCurrent.getClose() : 0;
+            long roundAsset = cash + (long) (spxValue + ndxValue + xauusdValue + usoValue + aaplValue + tltValue);
+            double returnRate = (double) (roundAsset - session.getInitialAsset()) / session.getInitialAsset() * 100;
 
             // priceData 구성 (보유 종목만)
             List<Map<String, Object>> priceDataList = new ArrayList<>();
 
-            // SPX
             Map<String, Object> spxData = new LinkedHashMap<>();
             spxData.put("ticker", "^SPX");
             spxData.put("open", spxCurrent.getOpen());
@@ -265,7 +316,6 @@ public class GameService {
             spxData.put("changeRate", spxChangeRate);
             priceDataList.add(spxData);
 
-            // NDX (보유 중인 경우만)
             if (ndxShares > 0 && ndxCurrent != null) {
                 Map<String, Object> ndxData = new LinkedHashMap<>();
                 ndxData.put("ticker", "^NDX");
@@ -277,12 +327,9 @@ public class GameService {
                 priceDataList.add(ndxData);
             }
 
-            // XAUUSD (보유 중인 경우만)
             if (xauusdShares > 0 && xauusdCurrent != null) {
                 double xauusdChangeRate = calcChangeRate(
-                        i > 0 && i < xauusdList.size() ? xauusdList.get(i - 1) : null,
-                        xauusdCurrent
-                );
+                        i > 0 && i < xauusdList.size() ? xauusdList.get(i - 1) : null, xauusdCurrent);
                 Map<String, Object> xauusdData = new LinkedHashMap<>();
                 xauusdData.put("ticker", "XAUUSD");
                 xauusdData.put("open", xauusdCurrent.getOpen());
@@ -293,21 +340,62 @@ public class GameService {
                 priceDataList.add(xauusdData);
             }
 
+            if (usoShares > 0 && usoCurrent != null) {
+                double usoChangeRate = calcChangeRate(usoPrev, usoCurrent);
+                Map<String, Object> usoData = new LinkedHashMap<>();
+                usoData.put("ticker", "USO");
+                usoData.put("open", usoCurrent.getOpen());
+                usoData.put("close", usoCurrent.getClose());
+                usoData.put("high", usoCurrent.getHigh());
+                usoData.put("low", usoCurrent.getLow());
+                usoData.put("changeRate", usoChangeRate);
+                priceDataList.add(usoData);
+            }
+
+            if (aaplShares > 0 && aaplCurrent != null) {
+                Map<String, Object> aaplData = new LinkedHashMap<>();
+                aaplData.put("ticker", "AAPL");
+                aaplData.put("open", aaplCurrent.getOpen());
+                aaplData.put("close", aaplCurrent.getClose());
+                aaplData.put("high", aaplCurrent.getHigh());
+                aaplData.put("low", aaplCurrent.getLow());
+                aaplData.put("changeRate", aaplChangeRate);
+                priceDataList.add(aaplData);
+            }
+
+            if (tltShares > 0 && tltCurrent != null) {
+                double tltChangeRate = calcChangeRate(
+                        i > 0 && i < tltList.size() ? tltList.get(i - 1) : null, tltCurrent);
+                Map<String, Object> tltData = new LinkedHashMap<>();
+                tltData.put("ticker", "TLT");
+                tltData.put("open", tltCurrent.getOpen());
+                tltData.put("close", tltCurrent.getClose());
+                tltData.put("high", tltCurrent.getHigh());
+                tltData.put("low", tltCurrent.getLow());
+                tltData.put("changeRate", tltChangeRate);
+                priceDataList.add(tltData);
+            }
+
             Map<String, Object> roundMap = new LinkedHashMap<>();
-            roundMap.put("round", i + 1);
+            roundMap.put("round", roundNumber);
             roundMap.put("date", spxCurrent.getTradeDate().toString());
             roundMap.put("priceData", priceDataList);
             roundMap.put("roundAsset", roundAsset);
-            roundMap.put("returnRate", returnRate);
+            roundMap.put("returnRate", Math.round(returnRate * 100.0) / 100.0);
+            roundMap.put("triggeredCards", triggeredCardIds);
             rounds.add(roundMap);
         }
 
-        Map<String, Object> result = new HashMap<>();
+// 결과 반환
+        Map<String, Object> result = new LinkedHashMap<>();
         result.put("rounds", rounds);
         result.put("finalCash", cash);
         result.put("finalSpx", spxShares);
         result.put("finalNdx", ndxShares);
         result.put("finalXauusd", xauusdShares);
+        result.put("finalUso", usoShares);
+        result.put("finalAapl", aaplShares);
+        result.put("finalTlt", tltShares);
         result.put("triggerCount", serializeTriggerCount(triggerMap));
         return result;
     }
@@ -317,17 +405,18 @@ public class GameService {
     // =============================================
 
     // 조건 체크
-    private boolean checkCondition(String condition,
-                                   double spxChangeRate, double ndxChangeRate) {
-        if (condition == null) return false;
-        return switch (condition) {
-            case "SPX_CHANGE <= -3" -> spxChangeRate <= -3;
-            case "SPX_CHANGE <= -5" -> spxChangeRate <= -5;
-            case "NDX_CHANGE >= 2"  -> ndxChangeRate >= 2;
-            case "NDX_CHANGE <= -4" -> ndxChangeRate <= -4;
-            default -> false;
-        };
-    }
+        private boolean checkCondition(String condition,
+        double spxChangeRate, double ndxChangeRate, double aaplChangeRate) {
+            return switch (condition) {
+                case "SPX_CHANGE <= -3"  -> spxChangeRate  <= -3;
+                case "SPX_CHANGE <= -5"  -> spxChangeRate  <= -5;
+                case "SPX_CHANGE >= 3"   -> spxChangeRate  >= 3;
+                case "NDX_CHANGE >= 2"   -> ndxChangeRate  >= 2;
+                case "NDX_CHANGE <= -4"  -> ndxChangeRate  <= -4;
+                case "AAPL_CHANGE <= -5" -> aaplChangeRate <= -5;
+                default -> false;
+            };
+        }
 
     // 등락률 계산
     private double calcChangeRate(StockPrice prev, StockPrice current) {
@@ -338,14 +427,20 @@ public class GameService {
 
     // ticker별 현재가 반환
     private double getTickerPrice(String ticker,
-                                  StockPrice spx, StockPrice ndx, StockPrice xauusd) {
+                                  StockPrice spx, StockPrice ndx, StockPrice xauusd,
+                                  StockPrice uso, StockPrice aapl, StockPrice tlt) {
         return switch (ticker) {
-            case "^SPX"   -> spx != null ? spx.getClose() : 0;
-            case "^NDX"   -> ndx != null ? ndx.getClose() : 0;
+            case "^SPX"   -> spx    != null ? spx.getClose()    : 0;
+            case "^NDX"   -> ndx    != null ? ndx.getClose()    : 0;
             case "XAUUSD" -> xauusd != null ? xauusd.getClose() : 0;
+            case "USO"    -> uso    != null ? uso.getClose()    : 0;
+            case "AAPL"   -> aapl   != null ? aapl.getClose()   : 0;
+            case "TLT"    -> tlt    != null ? tlt.getClose()    : 0;
             default -> 0;
         };
     }
+
+
 
     // 주가 데이터 로드
     private List<StockPrice> loadPriceList(GameSession session, String ticker) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #21

## 📝 작업 내용
> 기존 카드 계산 로직(BUY_ONCE, BUY_SPLIT, BUY_ON_CONDITION)에서 누락된 기능들을 고도화했습니다.  
> priority 기반 발동 순서 처리, 매도 카드(역발상 투자), 현금 부족 스킵, 파산 방지, BUY_EVERY_N 타입, AAPL 조건 체크, triggeredCards 응답 필드를 구현했습니다.

## 📁 수정된 파일

| 파일 | 변경 내용 |
|------|----------|
| `entity/GameSession.java` | `usoShares`, `aaplShares`, `tltShares` 필드 추가 / `update()` 메서드 파라미터 추가 |
| `service/GameService.java` | `calculateRounds()` 로직 전체 고도화 / `checkCondition()`, `getTickerPrice()` 수정 / `ALL_CARD_IDS` 11종으로 확장 |

## 🔍 주요 로직

### priority 기반 발동 순서
```java
// priority 오름차순 정렬 → 역발상 투자(8번) priority=1로 항상 먼저 발동
appliedCards.sort(Comparator.comparing(Card::getPriority));
```

### SELL_ON_CONDITION (역발상 투자)
```java
// SPX +3% 이상 시 보유 SPX의 15% 매도 → 현금 확보 후 매수 카드 처리
if ("SELL_ON_CONDITION".equals(card.getType())) {
    sellShares = spxShares * card.getRatio();
    spxShares -= sellShares;
    cash += (long)(sellShares * sellPrice);
}
```

### 현금 부족 스킵
```java
// 총자산의 5% 미만이면 매수 스킵 (부분 매수 없음)
if (cash < totalAsset * 0.05) continue;
```

### 파산 방지
```java
// 총자산이 initialAsset의 1% 이하면 모든 카드 발동 중지
if (totalAsset > session.getInitialAsset() * 0.01) { ... }
```

### BUY_EVERY_N (분할매수 장인)
```java
// 매 5라운드마다 발동
triggered = (roundNumber % 5 == 0);
```

### triggeredCards 응답 필드
```json
{
  "round": 5,
  "triggeredCards": [3, 4]
}
```

## ✅ 테스트 결과

| 케이스 | 결과 |
|--------|------|
| 서버 정상 실행 | ✅ 에러 없음 |
| priority 정렬 (역발상 투자 먼저 발동) | ✅ 정상 |
| SELL_ON_CONDITION 매도 처리 | ✅ 정상 |
| 현금 부족 시 매수 스킵 | ✅ 정상 |
| 파산 방지 동작 | ✅ 정상 |
| BUY_EVERY_N 5라운드 발동 | ✅ 정상 |
| triggeredCards 응답 반환 | ✅ 정상 |

## 🔗 연관된 이슈
close #21