### PR TITLE
[Feature] v3 API 반영(카드7~11) 및 게임 결과 화면 구현

### DIFF
--- a/frontEnd/lib/models/card_info.dart
+++ b/frontEnd/lib/models/card_info.dart
@@ -25,7 +25,7 @@ class CardInfo {
     }
   }
 
-  // 전체 카드 목록
+  // 전체 카드 목록 (v3 기준)
   static const List<CardInfo> all = [
     CardInfo(
       id: 1,
@@ -67,6 +67,42 @@ class CardInfo {
       name: '낙폭과대 사냥',
       description: 'NDX -4% 이하 시\n자산의 25% 나스닥 매수 (최대 3회)',
       emoji: '🎯',
+      ticker: '^NDX',
+    ),
+    // ── v3 추가 카드 ──────────────────────────
+    CardInfo(
+      id: 7,
+      name: '원유 베팅',
+      description: '현재 자산의 20%로\n원유 즉시 매수',
+      emoji: '🛢️',
+      ticker: 'USO',
+    ),
+    CardInfo(
+      id: 8,
+      name: '역발상 투자',
+      description: 'SPX +3% 이상 시\n자산의 15% SPX 매도',
+      emoji: '🔄',
+      ticker: '^SPX',
+    ),
+    CardInfo(
+      id: 9,
+      name: '애플 줍줍',
+      description: 'AAPL -5% 이하 시\n자산의 10% 애플 매수 (최대 5회)',
+      emoji: '🍎',
+      ticker: 'AAPL',
+    ),
+    CardInfo(
+      id: 10,
+      name: '채권 피난처',
+      description: '매 라운드\n자산의 3%씩 채권 매수',
+      emoji: '📜',
+      ticker: 'TLT',
+    ),
+    CardInfo(
+      id: 11,
+      name: '분할매수 장인',
+      description: '매 5라운드마다\n자산의 10% 나스닥 매수',
+      emoji: '📊',
       ticker: '^NDX',
     ),
   ];

--- a/frontEnd/lib/models/round_data.dart
+++ b/frontEnd/lib/models/round_data.dart
@@ -4,8 +4,9 @@ class RoundData {
   final int round;
   final String date;
   final List<PriceData> priceData;
-  final double? roundAsset;   // 카드 선택 전 = null
-  final double? returnRate;   // 카드 선택 전 = null
+  final double? roundAsset;       // 카드 선택 전 = null
+  final double? returnRate;       // 카드 선택 전 = null
+  final List<int> triggeredCards; // 이 라운드에 발동한 카드 ID 목록 (v3 추가)
 
   RoundData({
     required this.round,
@@ -13,20 +14,23 @@ class RoundData {
     required this.priceData,
     this.roundAsset,
     this.returnRate,
+    this.triggeredCards = const [],
   });
 
   factory RoundData.fromJson(Map<String, dynamic> json) {
-    final List<dynamic> priceList = json['priceData'] ?? [];
+    final List<dynamic> priceList     = json['priceData']      ?? [];
+    final List<dynamic> triggeredList = json['triggeredCards'] ?? [];
     return RoundData(
-      round: json['round'] ?? 0,
-      date: json['date'] ?? '',
-      priceData: priceList.map((e) => PriceData.fromJson(e)).toList(),
-      roundAsset: json['roundAsset'] != null
+      round:          json['round']      ?? 0,
+      date:           json['date']       ?? '',
+      priceData:      priceList.map((e) => PriceData.fromJson(e)).toList(),
+      roundAsset:     json['roundAsset'] != null
           ? (json['roundAsset'] as num).toDouble()
           : null,
-      returnRate: json['returnRate'] != null
+      returnRate:     json['returnRate'] != null
           ? (json['returnRate'] as num).toDouble()
           : null,
+      triggeredCards: triggeredList.map((e) => e as int).toList(),
     );
   }
 

--- a/frontEnd/lib/screens/game_result_screen.dart
+++ b/frontEnd/lib/screens/game_result_screen.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import '../models/game_session.dart';
+
+class GameResultScreen extends StatelessWidget {
+  final GameSession session;
+
+  const GameResultScreen({super.key, required this.session});
+
+  double get _finalAsset {
+    // 마지막 라운드의 roundAsset, 없으면 initialAsset
+    for (int i = session.rounds.length - 1; i >= 0; i--) {
+      if (session.rounds[i].roundAsset != null) {
+        return session.rounds[i].roundAsset!;
+      }
+    }
+    return session.initialAsset;
+  }
+
+  double get _finalReturnRate {
+    for (int i = session.rounds.length - 1; i >= 0; i--) {
+      if (session.rounds[i].returnRate != null) {
+        return session.rounds[i].returnRate!;
+      }
+    }
+    return 0.0;
+  }
+
+  bool get _isProfit => _finalReturnRate >= 0;
+
+  String _formatNumber(double value) {
+    return value
+        .toStringAsFixed(0)
+        .replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (m) => '${m[1]},',
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final profit = _isProfit;
+    final returnRate = _finalReturnRate;
+    final color = profit ? const Color(0xFFE03131) : const Color(0xFF1971C2);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFFAF9F5),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 40, 24, 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 타이틀
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFEEEDFE),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: const Text(
+                  '게임 종료',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF3C3489),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                session.scenarioTitle,
+                style: const TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.w800,
+                  color: Color(0xFF111111),
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '${session.totalRounds}라운드 완료',
+                style: const TextStyle(fontSize: 14, color: Color(0xFF6B7684)),
+              ),
+
+              const Spacer(),
+
+              // 자산 변화 카드
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(24),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(20),
+                  border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
+                ),
+                child: Column(
+                  children: [
+                    // 시작 자산
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        const Text(
+                          '시작 자산',
+                          style: TextStyle(fontSize: 14, color: Color(0xFF6B7684)),
+                        ),
+                        Text(
+                          '₩${_formatNumber(session.initialAsset)}',
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                            color: Color(0xFF111111),
+                          ),
+                        ),
+                      ],
+                    ),
+
+                    // 화살표
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Container(
+                              height: 1,
+                              color: const Color(0xFFEEEEEE),
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 12),
+                            child: Icon(
+                              profit
+                                  ? Icons.arrow_downward_rounded
+                                  : Icons.arrow_downward_rounded,
+                              color: color,
+                              size: 28,
+                            ),
+                          ),
+                          Expanded(
+                            child: Container(
+                              height: 1,
+                              color: const Color(0xFFEEEEEE),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+
+                    // 최종 자산
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        const Text(
+                          '최종 자산',
+                          style: TextStyle(fontSize: 14, color: Color(0xFF6B7684)),
+                        ),
+                        Text(
+                          '₩${_formatNumber(_finalAsset)}',
+                          style: TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.w800,
+                            color: color,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+
+              const SizedBox(height: 16),
+
+              // 수익률 뱃지
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 18),
+                decoration: BoxDecoration(
+                  color: color.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: color.withValues(alpha: 0.2), width: 1),
+                ),
+                child: Column(
+                  children: [
+                    Text(
+                      '${profit ? '+' : ''}${returnRate.toStringAsFixed(2)}%',
+                      style: TextStyle(
+                        fontSize: 36,
+                        fontWeight: FontWeight.w800,
+                        color: color,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      profit ? '수익을 달성했어요 🎉' : '손실이 발생했어요',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: color.withValues(alpha: 0.8),
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              const Spacer(),
+
+              // 다시 하기 버튼
+              SizedBox(
+                width: double.infinity,
+                height: 52,
+                child: ElevatedButton(
+                  onPressed: () {
+                    // 시나리오 선택 화면까지 전부 pop
+                    Navigator.of(context).popUntil((route) => route.isFirst);
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF111111),
+                    foregroundColor: Colors.white,
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                  ),
+                  child: const Text(
+                    '다시 시작하기',
+                    style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontEnd/lib/screens/game_screen.dart
+++ b/frontEnd/lib/screens/game_screen.dart
@@ -7,6 +7,7 @@ import '../models/card_info.dart';
 import '../services/game_service.dart';
 import '../services/mock_data.dart';
 import '../widgets/stock_chart.dart';
+import 'game_result_screen.dart';
 
 class GameScreen extends StatefulWidget {
   final GameSession session;
@@ -37,23 +38,20 @@ class _GameScreenState extends State<GameScreen> {
   }
 
   List<RoundData> get _chartData => _session.getChartData(
-    _currentRoundIndex.clamp(0, _session.rounds.length - 1),
-  );
+        _currentRoundIndex.clamp(0, _session.rounds.length - 1),
+      );
 
   // 현재 라운드 번호 (1-based)
   int get _currentRound1 => _currentRoundIndex + 1;
 
   bool get _showCard {
     if (_cardSelected) return false;
-    // cardSelectRounds가 있으면 그 기준으로, 없으면 1라운드에 표시
     if (_session.cardSelectRounds.isNotEmpty) {
       return _session.isCardSelectRound(_currentRound1);
     }
     return _currentRound1 == 1;
   }
 
-  // 카드 선택 전엔 종료 버튼 안 보임
-  // 다음 라운드가 카드 선택 라운드면 마지막 아님
   bool get _isLastRound {
     if (!_cardSelected) return false;
     final nextRound = _currentRoundIndex + 2;
@@ -77,7 +75,7 @@ class _GameScreenState extends State<GameScreen> {
   // ── 자동 진행 ──────────────────────────────
   void _startAutoPlay() {
     setState(() => _isAutoPlaying = true);
-    _autoTimer = Timer.periodic(const Duration(milliseconds: 100), (_) {
+    _autoTimer = Timer.periodic(const Duration(milliseconds: 500), (_) {
       if (!mounted) return;
       final nextRound = _currentRoundIndex + 2;
       final willHitCard = _session.isCardSelectRound(nextRound);
@@ -114,13 +112,24 @@ class _GameScreenState extends State<GameScreen> {
     });
   }
 
+  // ── 게임 종료 → 결과 화면 ───────────────────
+  void _goToResult() {
+    _stopAutoPlay();
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => GameResultScreen(session: _session),
+      ),
+    );
+  }
+
   // ── 카드 선택 (실제 API) ────────────────────
   Future<void> _onCardSelected(int cardId) async {
     setState(() => _isSubmitting = true);
     try {
       final result = await _gameService.submitAction(
         sessionId: _session.sessionId,
-        round: _currentRound1,  // 1-based 라운드 번호
+        round: _currentRound1,
         cardId: cardId,
       );
       _applyActionResult(result);
@@ -148,7 +157,6 @@ class _GameScreenState extends State<GameScreen> {
 
   // ── ActionResult 반영 ───────────────────────
   void _applyActionResult(ActionResult result) {
-    // 디버그 확인용
     print('=== ActionResult ===');
     print('nextEventRound: ${result.nextEventRound}');
     print('nextCardOptions: ${result.nextCardOptions}');
@@ -156,16 +164,13 @@ class _GameScreenState extends State<GameScreen> {
     if (result.rounds.isNotEmpty) {
       print('rounds: ${result.rounds.first.round} ~ ${result.rounds.last.round}');
     }
-    // 기존 rounds에 새 rounds 덮어쓰기
-    // 서버가 준 rounds를 index 기준으로 교체
-    // 기존보다 크면 늘려서 추가
+
     final updatedRounds = List<RoundData>.from(_session.rounds);
     for (final newRound in result.rounds) {
       final index = newRound.round - 1;
       if (index < updatedRounds.length) {
-        updatedRounds[index] = newRound;         // 기존 자리 교체
+        updatedRounds[index] = newRound;
       } else {
-        // 기존 리스트보다 크면 빈칸 채우며 추가
         while (updatedRounds.length < index) {
           updatedRounds.add(updatedRounds.last);
         }
@@ -289,6 +294,8 @@ class _GameScreenState extends State<GameScreen> {
                 ? () => _onMockCardSelected(_currentCardOptions.isNotEmpty ? _currentCardOptions[0] : 1)
                 : null,
           )),
+          const SizedBox(width: 6),
+          Expanded(child: _devBtn('결과 화면', _goToResult)),
         ],
       ),
     );
@@ -343,49 +350,81 @@ class _GameScreenState extends State<GameScreen> {
         borderRadius: BorderRadius.circular(16),
         border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
       ),
-      child: Row(
+      child: Column(
         children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(round.date, style: const TextStyle(fontSize: 12, color: Color(0xFF6B7684))),
-                const SizedBox(height: 4),
-                Row(
-                  children: round.priceData.map((price) => Padding(
-                    padding: const EdgeInsets.only(right: 12),
-                    child: Row(
-                      children: [
-                        Container(width: 8, height: 8, decoration: BoxDecoration(
-                          color: tickerColor(price.ticker), shape: BoxShape.circle,
-                        )),
-                        const SizedBox(width: 4),
-                        Text(
-                          '${price.ticker} ${price.changeRate >= 0 ? '+' : ''}${price.changeRate.toStringAsFixed(2)}%',
-                          style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600,
-                            color: price.isPositive ? const Color(0xFFE03131) : const Color(0xFF1971C2)),
-                        ),
-                      ],
-                    ),
-                  )).toList(),
-                ),
-              ],
-            ),
-          ),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
+          Row(
             children: [
-              const Text('총자산', style: TextStyle(fontSize: 11, color: Color(0xFF6B7684))),
-              Text('₩${_formatNumber(asset)}',
-                style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Color(0xFF111111))),
-              if (returnRate != null)
-                Text(
-                  '${isPos ? '+' : ''}${returnRate.toStringAsFixed(2)}%',
-                  style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600,
-                    color: isPos ? const Color(0xFFE03131) : const Color(0xFF1971C2)),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(round.date, style: const TextStyle(fontSize: 12, color: Color(0xFF6B7684))),
+                    const SizedBox(height: 4),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 4,
+                      children: round.priceData.map((price) => Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(width: 8, height: 8, decoration: BoxDecoration(
+                            color: tickerColor(price.ticker), shape: BoxShape.circle,
+                          )),
+                          const SizedBox(width: 4),
+                          Text(
+                            '${price.ticker} ${price.changeRate >= 0 ? '+' : ''}${price.changeRate.toStringAsFixed(2)}%',
+                            style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600,
+                              color: price.isPositive ? const Color(0xFFE03131) : const Color(0xFF1971C2)),
+                          ),
+                        ],
+                      )).toList(),
+                    ),
+                  ],
                 ),
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  const Text('총자산', style: TextStyle(fontSize: 11, color: Color(0xFF6B7684))),
+                  Text('₩${_formatNumber(asset)}',
+                    style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Color(0xFF111111))),
+                  if (returnRate != null)
+                    Text(
+                      '${isPos ? '+' : ''}${returnRate.toStringAsFixed(2)}%',
+                      style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600,
+                        color: isPos ? const Color(0xFFE03131) : const Color(0xFF1971C2)),
+                    ),
+                ],
+              ),
             ],
           ),
+
+          // triggeredCards 표시
+          if (round.triggeredCards.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              decoration: BoxDecoration(
+                color: const Color(0xFFEEEDFE),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Wrap(
+                spacing: 6,
+                children: round.triggeredCards.map((id) {
+                  final card = CardInfo.fromId(id);
+                  if (card == null) return const SizedBox.shrink();
+                  return Text(
+                    '${card.emoji} ${card.name} 발동',
+                    style: const TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: Color(0xFF3C3489),
+                    ),
+                  );
+                }).toList(),
+              ),
+            ),
+          ],
         ],
       ),
     );
@@ -473,20 +512,28 @@ class _GameScreenState extends State<GameScreen> {
         ),
         const SizedBox(width: 10),
 
-        // 다음 라운드 버튼
+        // 다음 라운드 / 게임 종료 버튼
         Expanded(
           child: SizedBox(
             height: 52,
             child: ElevatedButton(
-              onPressed: (_isLastRound || _isAutoPlaying) ? null : _nextRound,
+              onPressed: _isAutoPlaying
+                  ? null
+                  : _isLastRound
+                      ? _goToResult
+                      : _nextRound,
               style: ElevatedButton.styleFrom(
-                backgroundColor: _isLastRound ? const Color(0xFFEEEEEE) : const Color(0xFF111111),
-                foregroundColor: _isLastRound ? const Color(0xFFAAAAAA) : Colors.white,
+                backgroundColor: _isLastRound
+                    ? const Color(0xFF3C3489)
+                    : const Color(0xFF111111),
+                foregroundColor: Colors.white,
                 elevation: 0,
                 shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
               ),
               child: Text(
-                _isLastRound ? '게임 종료' : '다음 라운드 ($_currentRound1 / ${_session.totalRounds})',
+                _isLastRound
+                    ? '결과 보기'
+                    : '다음 라운드 ($_currentRound1 / ${_session.totalRounds})',
                 style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
               ),
             ),

--- a/frontEnd/lib/services/api_client.dart
+++ b/frontEnd/lib/services/api_client.dart
@@ -2,7 +2,8 @@ import 'package:dio/dio.dart';
 
 class ApiClient {
   //static const String _baseUrl = 'http://172.22.165.231:8080';
-  static const String _baseUrl = 'http://172.18.16.192:8080';
+  //static const String _baseUrl = 'http://172.18.16.192:8080';
+  static const String _baseUrl = 'http://172.18.35.92:8080';
   
 
   final Dio _dio = Dio(BaseOptions(

--- a/frontEnd/lib/widgets/stock_chart.dart
+++ b/frontEnd/lib/widgets/stock_chart.dart
@@ -5,13 +5,24 @@ import '../models/price_data.dart';
 
 // 종목별 고정 색상
 const Map<String, Color> tickerColors = {
-  '^SPX': Color(0xFF1971C2),  // 파랑
-  '^NDX': Color(0xFF7048E8),  // 보라
-  'GLD':  Color(0xFFE67700),  // 노랑
+  '^SPX':  Color(0xFF1971C2),  // 파랑
+  '^NDX':  Color(0xFF7048E8),  // 보라
+  'GLD':   Color(0xFFE67700),  // 주황
+  'USO':   Color(0xFF2F9E44),  // 초록
+  'AAPL':  Color(0xFF868E96),  // 회색
+  'TLT':   Color(0xFFE64980),  // 분홍
 };
+
+// 10배 배율이 필요한 종목 목록
+// ^SPX, ^NDX는 1200~1700 범위라 배율 불필요
+// 나머지는 100 이하라 10배 적용
+const Set<String> _scaledTickers = {'GLD', 'USO', 'AAPL', 'TLT'};
 
 Color tickerColor(String ticker) =>
     tickerColors[ticker] ?? const Color(0xFF6B7684);
+
+double _applyScale(String ticker, double value) =>
+    _scaledTickers.contains(ticker) ? value * 10 : value;
 
 class StockChart extends StatelessWidget {
   final List<RoundData> rounds;
@@ -34,24 +45,48 @@ class StockChart extends StatelessWidget {
     return result;
   }
 
-  // 특정 ticker의 FlSpot 리스트
+  // 특정 ticker의 FlSpot 리스트 (배율 적용)
   List<FlSpot> _spots(String ticker) {
     final List<FlSpot> spots = [];
     for (int i = 0; i < rounds.length; i++) {
       final price = rounds[i].getPrice(ticker);
       if (price != null) {
-        spots.add(FlSpot(i.toDouble(), price.close));
+        spots.add(FlSpot(i.toDouble(), _applyScale(ticker, price.close)));
       }
     }
     return spots;
   }
 
-  // Y축 범위
+  // roundAsset 기반 내 자산 FlSpot 리스트
+  List<FlSpot> get _assetSpots {
+    final List<FlSpot> spots = [];
+    for (int i = 0; i < rounds.length; i++) {
+      final asset = rounds[i].roundAsset;
+      if (asset != null) {
+        // 자산을 종목 스케일(~1200)에 맞게 축소: 10,000,000 → 1000 수준
+        spots.add(FlSpot(i.toDouble(), asset / 10000));
+      }
+    }
+    return spots;
+  }
+
+  // Y축 범위 (배율 적용된 종목 가격 + 자산 스팟 모두 포함)
   double get _minY {
     double min = double.infinity;
+    for (final ticker in _tickers) {
+      for (final r in rounds) {
+        final price = r.getPrice(ticker);
+        if (price != null) {
+          final v = _applyScale(ticker, price.close);
+          if (v < min) min = v;
+        }
+      }
+    }
     for (final r in rounds) {
-      for (final p in r.priceData) {
-        if (p.close < min) min = p.close;
+      final asset = r.roundAsset;
+      if (asset != null) {
+        final v = asset / 10000;
+        if (v < min) min = v;
       }
     }
     return min == double.infinity ? 0 : min * 0.97;
@@ -59,9 +94,20 @@ class StockChart extends StatelessWidget {
 
   double get _maxY {
     double max = double.negativeInfinity;
+    for (final ticker in _tickers) {
+      for (final r in rounds) {
+        final price = r.getPrice(ticker);
+        if (price != null) {
+          final v = _applyScale(ticker, price.close);
+          if (v > max) max = v;
+        }
+      }
+    }
     for (final r in rounds) {
-      for (final p in r.priceData) {
-        if (p.close > max) max = p.close;
+      final asset = r.roundAsset;
+      if (asset != null) {
+        final v = asset / 10000;
+        if (v > max) max = v;
       }
     }
     return max == double.negativeInfinity ? 100 : max * 1.03;
@@ -76,32 +122,96 @@ class StockChart extends StatelessWidget {
     }
 
     final tickers = _tickers;
+    final assetSpots = _assetSpots;
+    final hasAsset = assetSpots.isNotEmpty;
+
+    // 종목 선 + 자산 선 합치기
+    final List<LineChartBarData> lineBars = [
+      // 종목별 선
+      ...tickers.map((ticker) {
+        final spots = _spots(ticker);
+        final color = tickerColor(ticker);
+        return LineChartBarData(
+          spots: spots,
+          color: color,
+          barWidth: 1.5,
+          isCurved: true,
+          curveSmoothness: 0.3,
+          dotData: FlDotData(
+            show: true,
+            getDotPainter: (spot, _, __, index) {
+              final isLastDot = index == spots.length - 1;
+              return FlDotCirclePainter(
+                radius: isLastDot ? 3 : 0,
+                color: color,
+                strokeWidth: isLastDot ? 2 : 0,
+                strokeColor: Colors.white,
+              );
+            },
+          ),
+          belowBarData: BarAreaData(show: false),
+        );
+      }),
+
+      // 내 자산 선 (흰색 굵은 선)
+      if (hasAsset)
+        LineChartBarData(
+          spots: assetSpots,
+          color: const Color(0xFF111111),
+          barWidth: 2.5,
+          isCurved: true,
+          curveSmoothness: 0.3,
+          dotData: FlDotData(
+            show: true,
+            getDotPainter: (spot, _, __, index) {
+              final isLastDot = index == assetSpots.length - 1;
+              return FlDotCirclePainter(
+                radius: isLastDot ? 4 : 0,
+                color: const Color(0xFF111111),
+                strokeWidth: isLastDot ? 2 : 0,
+                strokeColor: Colors.white,
+              );
+            },
+          ),
+          belowBarData: BarAreaData(
+            show: true,
+            color: const Color(0xFF111111).withValues(alpha: 0.05),
+          ),
+        ),
+    ];
 
     return Column(
       children: [
-        // 종목 범례 (여러 종목일 때만 표시)
-        if (tickers.length > 1)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: tickers.map((t) => Padding(
-                padding: const EdgeInsets.only(left: 12),
+        // 범례
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              // 종목 범례
+              ...tickers.map((t) => Padding(
+                padding: const EdgeInsets.only(left: 10),
                 child: Row(
                   children: [
-                    Container(
-                      width: 12, height: 3,
-                      color: tickerColor(t),
+                    Container(width: 10, height: 2.5, color: tickerColor(t)),
+                    const SizedBox(width: 3),
+                    Text(
+                      _scaledTickers.contains(t) ? '$t×10' : t,
+                      style: const TextStyle(fontSize: 9, color: Color(0xFF6B7684)),
                     ),
-                    const SizedBox(width: 4),
-                    Text(t, style: const TextStyle(
-                      fontSize: 10, color: Color(0xFF6B7684),
-                    )),
                   ],
                 ),
-              )).toList(),
-            ),
+              )),
+              // 자산 범례
+              if (hasAsset) ...[
+                const SizedBox(width: 10),
+                Container(width: 10, height: 2.5, color: const Color(0xFF111111)),
+                const SizedBox(width: 3),
+                const Text('내 자산', style: TextStyle(fontSize: 9, color: Color(0xFF6B7684))),
+              ],
+            ],
           ),
+        ),
 
         // 차트
         Expanded(
@@ -112,34 +222,7 @@ class StockChart extends StatelessWidget {
               minX: 0,
               maxX: (rounds.length - 1).toDouble(),
 
-              lineBarsData: tickers.map((ticker) {
-                final spots = _spots(ticker);
-                final color = tickerColor(ticker);
-                final isLast = ticker == tickers.last;
-                return LineChartBarData(
-                  spots: spots,
-                  color: color,
-                  barWidth: 2,
-                  isCurved: true,
-                  curveSmoothness: 0.3,
-                  dotData: FlDotData(
-                    show: true,
-                    getDotPainter: (spot, _, __, index) {
-                      final isLastDot = index == spots.length - 1;
-                      return FlDotCirclePainter(
-                        radius: isLastDot ? 4 : 0,
-                        color: color,
-                        strokeWidth: isLastDot ? 2 : 0,
-                        strokeColor: Colors.white,
-                      );
-                    },
-                  ),
-                  belowBarData: BarAreaData(
-                    show: isLast,
-                    color: color.withValues(alpha: 0.06),
-                  ),
-                );
-              }).toList(),
+              lineBarsData: lineBars,
 
               gridData: FlGridData(
                 show: true,
@@ -158,6 +241,7 @@ class StockChart extends StatelessWidget {
                 ),
               ),
 
+              // Y축 숫자 제거
               titlesData: FlTitlesData(
                 bottomTitles: AxisTitles(
                   sideTitles: SideTitles(
@@ -183,18 +267,7 @@ class StockChart extends StatelessWidget {
                     },
                   ),
                 ),
-                leftTitles: AxisTitles(
-                  sideTitles: SideTitles(
-                    showTitles: true,
-                    reservedSize: 52,
-                    getTitlesWidget: (value, _) => Text(
-                      value.toStringAsFixed(0),
-                      style: const TextStyle(
-                        fontSize: 9, color: Color(0xFF6B7684),
-                      ),
-                    ),
-                  ),
-                ),
+                leftTitles:  const AxisTitles(sideTitles: SideTitles(showTitles: false)),
                 topTitles:   const AxisTitles(sideTitles: SideTitles(showTitles: false)),
                 rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
               ),
@@ -205,8 +278,8 @@ class StockChart extends StatelessWidget {
                     final index = spot.x.toInt();
                     final date = index < rounds.length ? rounds[index].date : '';
                     return LineTooltipItem(
-                      '$date\n${spot.y.toStringAsFixed(2)}',
-                     const TextStyle(
+                      '$date\n${spot.y.toStringAsFixed(0)}',
+                      const TextStyle(
                         color: Colors.white, fontSize: 10,
                         fontWeight: FontWeight.w500,
                       ),

--- a/frontEnd/lib/폴더구조.txt
+++ b/frontEnd/lib/폴더구조.txt
@@ -1,21 +1,22 @@
 lib/
   models/
     scenario.dart
-    game_session.dart      ← 추가 예정 (게임 시작 응답)
-    round_data.dart        ← 추가 예정 (라운드 데이터)
-    action_result.dart     ← 추가 예정 (카드 선택 결과)
+    game_session.dart
+    round_data.dart        ← triggeredCards 필드 추가 (v3)
+    action_result.dart
+    card_info.dart         ← 카드 11개로 확장 (v3)
+    price_data.dart
 
   services/
     api_client.dart
-    game_service.dart      ← startGame(), getRound(), submitAction() 추가 예정
+    game_service.dart
+    mock_data.dart
 
   screens/
     scenario_screen.dart
-    game_screen.dart       ← 추가 예정
-    result_screen.dart     ← 추가 예정
+    game_screen.dart       ← triggeredCards 표시, 결과화면 연결 (v3)
+    game_result_screen.dart ← 신규 추가 (v3)
 
   widgets/
     scenario_card.dart
-    stock_chart.dart       ← 추가 예정
-    action_card.dart       ← 추가 예정
-    asset_card.dart        ← 추가 예정
+    stock_chart.dart       ← 10배 배율, 내 자산 선, Y축 제거 (v3)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #23

## 📝 작업 내용

### 🗂️ 폴더 구조
```
lib/
  models/
    card_info.dart         # 수정 - 카드 7~11번 추가 (v3)
    round_data.dart        # 수정 - triggeredCards 필드 추가 (v3)
  screens/
    game_screen.dart       # 수정 - triggeredCards 표시, 결과화면 연결
    game_result_screen.dart # 새로 추가 - 게임 종료 결과 화면
  widgets/
    stock_chart.dart       # 수정 - 10배 고정 배율, 내 자산 선, Y축 제거
```

---

### ⚙️ API 변경사항 (v3)

**POST /game/round/action 응답 추가**
```json
{
  "rounds": [
    {
      "triggeredCards": [1, 3]
    }
  ]
}
```

**카드 목록 확장**
```
기존: 6개 (거인의어깨 ~ 낙폭과대사냥)
변경: 11개 추가
      7: 원유 베팅 (USO, 즉시 20% 매수)
      8: 역발상 투자 (^SPX, 상승 시 15% 매도)
      9: 애플 줍줍 (AAPL, 하락 시 10% 매수, 최대 5회)
      10: 채권 피난처 (TLT, 매 라운드 3% 매수)
      11: 분할매수 장인 (^NDX, 매 5라운드 10% 매수)
```

---

### 🖥️ 구현된 기능

**차트 개선**
- Y축 숫자 제거 (종목 간 스케일 혼란 방지)
- GLD / USO / AAPL / TLT 고정 10배 배율 적용 (바닥에 기는 문제 해결)
- 내 자산(roundAsset) 흐름을 검정 선으로 차트에 함께 표시
- 배율 적용 종목 범례에 ×10 표기 추가

**triggeredCards 표시**
- 카드가 발동된 라운드에 발동 카드 이름 라운드 정보 영역에 표시
- 이모티콘 + 카드명 + 발동 텍스트

**게임 종료 결과 화면 (GameResultScreen)**
- 시작자산 → 화살표 → 최종자산 한눈에 표시
- 수익률 크게 표시 (수익 빨강 / 손실 파랑 색상 구분)
- 다시 시작하기 버튼 (시나리오 선택 화면으로 이동)
- 개발용 버튼에 결과 화면 바로가기 추가

---

### 🔥 트러블슈팅

**1. GLD/USO/AAPL/TLT 차트 바닥에 기는 문제**
```
원인: SPX/NDX는 1200~1700 범위
      GLD/USO/AAPL/TLT는 20~200 범위
      같은 Y축에 그리면 스케일 차이로 바닥에 납작하게 붙음
해결: 해당 종목에 고정 10배 배율 적용
      Y축은 숫자 제거하여 혼란 방지
```

**2. 나중에 추가되는 종목 차트 기준점 문제**
```
원인: 25라운드에 새 종목 추가 시
      기준점을 어디로 잡아야 할지 애매함
해결: 각 종목이 처음 등장하는 라운드의 close 기준으로
      10배 배율만 적용하여 단순하게 처리
```

---
