### PR TITLE
[Feature] 몬테카를로 시뮬레이션 사전 작업 — 게임 로직 Python 포팅

### DIFF
--- a/backend/python_simulation/data_loader.py
+++ b/backend/python_simulation/data_loader.py
@@ -1,0 +1,40 @@
+import os
+import pandas as pd
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+
+CSV_FILES = {
+    '^SPX':  os.path.join(DATA_DIR, '^spx_d.csv'),
+    '^NDX':  os.path.join(DATA_DIR, '^ndx_d.csv'),
+    'GLD':   os.path.join(DATA_DIR, 'xauusd_d.csv'),  # XAUUSD = GLD
+    'USO':   os.path.join(DATA_DIR, 'uso_d.csv'),
+    'AAPL':  os.path.join(DATA_DIR, 'aapl_d.csv'),
+    'TLT':   os.path.join(DATA_DIR, 'tlt_d.csv'),
+}
+
+_cache = {}
+
+def load_all() -> dict:
+    """전체 종목 CSV 로드 (캐시 사용)"""
+    if _cache:
+        return _cache
+    for ticker, path in CSV_FILES.items():
+        if not os.path.exists(path):
+            print(f'[경고] 파일 없음: {path}')
+            _cache[ticker] = pd.DataFrame()
+            continue
+        df = pd.read_csv(path)
+        df.columns = [c.strip() for c in df.columns]
+        df['Date'] = pd.to_datetime(df['Date'])
+        df = df.sort_values('Date').reset_index(drop=True)
+        _cache[ticker] = df
+    return _cache
+
+def get_price_list(start_date: str, ticker: str) -> pd.DataFrame:
+    """start_date 이후 해당 ticker 데이터 반환"""
+    all_data = load_all()
+    df = all_data.get(ticker, pd.DataFrame())
+    if df.empty:
+        return df
+    df = df[df['Date'] >= pd.to_datetime(start_date)].reset_index(drop=True)
+    return df

--- a/backend/python_simulation/game_logic.py
+++ b/backend/python_simulation/game_logic.py
@@ -1,0 +1,196 @@
+"""
+Java GameService.calculateRounds() 를 Python으로 포팅
+카드 정의, 조건 체크, 라운드 계산 로직 포함
+"""
+from data_loader import get_price_list
+
+INITIAL_ASSET = 10_000_000
+
+CARDS = {
+    1:  {'id': 1,  'name': '거인의 어깨',   'ticker': '^SPX', 'ratio': 0.30, 'type': 'BUY_ONCE',          'condition': None,               'max_trigger': None, 'priority': 1},
+    2:  {'id': 2,  'name': '황금 적립',     'ticker': 'GLD',  'ratio': 0.05, 'type': 'BUY_SPLIT',         'condition': None,               'max_trigger': None, 'priority': 2},
+    3:  {'id': 3,  'name': '공포탐욕',      'ticker': '^SPX', 'ratio': 0.20, 'type': 'BUY_ON_CONDITION',  'condition': 'SPX_CHANGE <= -3', 'max_trigger': None, 'priority': 3},
+    4:  {'id': 4,  'name': '금 피난처',     'ticker': 'GLD',  'ratio': 0.15, 'type': 'BUY_ON_CONDITION',  'condition': 'SPX_CHANGE <= -5', 'max_trigger': None, 'priority': 4},
+    5:  {'id': 5,  'name': '기술의 파도',   'ticker': '^NDX', 'ratio': 0.10, 'type': 'BUY_ON_CONDITION',  'condition': 'NDX_CHANGE >= 2',  'max_trigger': None, 'priority': 5},
+    6:  {'id': 6,  'name': '낙폭과대 사냥', 'ticker': '^NDX', 'ratio': 0.25, 'type': 'BUY_ON_CONDITION',  'condition': 'NDX_CHANGE <= -4', 'max_trigger': 3,    'priority': 6},
+    7:  {'id': 7,  'name': '원유 베팅',     'ticker': 'USO',  'ratio': 0.20, 'type': 'BUY_ONCE',          'condition': None,               'max_trigger': None, 'priority': 7},
+    8:  {'id': 8,  'name': '역발상 투자',   'ticker': '^SPX', 'ratio': 0.15, 'type': 'SELL_ON_CONDITION', 'condition': 'SPX_CHANGE >= 3',  'max_trigger': None, 'priority': 1},
+    9:  {'id': 9,  'name': '애플 줍줍',     'ticker': 'AAPL', 'ratio': 0.10, 'type': 'BUY_ON_CONDITION',  'condition': 'AAPL_CHANGE <= -5','max_trigger': 5,    'priority': 9},
+    10: {'id': 10, 'name': '채권 피난처',   'ticker': 'TLT',  'ratio': 0.03, 'type': 'BUY_SPLIT',         'condition': None,               'max_trigger': None, 'priority': 10},
+    11: {'id': 11, 'name': '분할매수 장인', 'ticker': '^NDX', 'ratio': 0.10, 'type': 'BUY_EVERY_N',       'condition': None,               'max_trigger': None, 'priority': 11},
+}
+
+TICKERS = ['^SPX', '^NDX', 'GLD', 'USO', 'AAPL', 'TLT']
+CARD_SELECT_ROUNDS = [1, 25, 50, 75]
+
+
+def _calc_change_rate(prev_close, curr_close) -> float:
+    if prev_close is None or prev_close <= 0:
+        return 0.0
+    rate = (curr_close - prev_close) / prev_close * 100
+    return round(rate, 2)
+
+
+def _check_condition(condition, spx_change, ndx_change, aapl_change) -> bool:
+    if condition is None:
+        return False
+    if condition == 'SPX_CHANGE <= -3':    return spx_change  <= -3
+    elif condition == 'SPX_CHANGE <= -5':  return spx_change  <= -5
+    elif condition == 'SPX_CHANGE >= 3':   return spx_change  >= 3
+    elif condition == 'NDX_CHANGE >= 2':   return ndx_change  >= 2
+    elif condition == 'NDX_CHANGE <= -4':  return ndx_change  <= -4
+    elif condition == 'AAPL_CHANGE <= -5': return aapl_change <= -5
+    return False
+
+
+def run_game(start_date: str, card_selections: dict, initial_asset: int = INITIAL_ASSET) -> dict:
+    """
+    게임 실행 메인 함수
+    :param start_date: 시작 날짜 (예: "2008-09-02")
+    :param card_selections: {라운드: 카드ID} (예: {1: 1, 25: 2, 50: 3, 75: 4})
+    :param initial_asset: 초기 자산 (기본 10,000,000)
+    """
+    price_data = {ticker: get_price_list(start_date, ticker) for ticker in TICKERS}
+
+    spx_list = price_data['^SPX']
+    if len(spx_list) < 100:
+        raise ValueError(f'SPX 데이터 부족 ({len(spx_list)}개). start_date를 확인하세요.')
+
+    cash = float(initial_asset)
+    shares = {t: 0.0 for t in TICKERS}
+    trigger_map = {}
+    applied_card_ids = []
+    rounds_result = []
+
+    for i in range(100):
+        if i >= len(spx_list):
+            break
+
+        round_number = i + 1
+
+        # 카드 선택 라운드 처리
+        if round_number in card_selections:
+            card_id = card_selections[round_number]
+            if card_id not in applied_card_ids:
+                applied_card_ids.append(card_id)
+                card = CARDS[card_id]
+                # BUY_ONCE 즉시 매수
+                if card['type'] == 'BUY_ONCE':
+                    ticker = card['ticker']
+                    df = price_data.get(ticker)
+                    if df is not None and len(df) > i:
+                        price = df.iloc[i]['Close']
+                        if price > 0:
+                            buy_amount = cash * card['ratio']
+                            cash -= buy_amount
+                            shares[ticker] += buy_amount / price
+
+        # 현재 라운드 주가
+        spx_curr = spx_list.iloc[i]
+        spx_prev = spx_list.iloc[i - 1] if i > 0 else None
+
+        def get_curr(ticker):
+            df = price_data[ticker]
+            return df.iloc[i] if i < len(df) else None
+
+        def get_prev(ticker):
+            df = price_data[ticker]
+            return df.iloc[i - 1] if (i > 0 and i < len(df)) else None
+
+        ndx_curr  = get_curr('^NDX');  ndx_prev  = get_prev('^NDX')
+        aapl_curr = get_curr('AAPL'); aapl_prev = get_prev('AAPL')
+        gld_curr  = get_curr('GLD')
+        uso_curr  = get_curr('USO')
+        tlt_curr  = get_curr('TLT')
+
+        def close(row):
+            return float(row['Close']) if row is not None else 0.0
+
+        spx_change  = _calc_change_rate(close(spx_prev),  close(spx_curr))
+        ndx_change  = _calc_change_rate(close(ndx_prev),  close(ndx_curr))
+        aapl_change = _calc_change_rate(close(aapl_prev), close(aapl_curr))
+
+        prices = {
+            '^SPX': close(spx_curr), '^NDX': close(ndx_curr),
+            'GLD':  close(gld_curr), 'USO':  close(uso_curr),
+            'AAPL': close(aapl_curr),'TLT':  close(tlt_curr),
+        }
+
+        total_asset = cash + sum(shares[t] * prices[t] for t in TICKERS)
+        triggered_card_ids = []
+
+        # 파산 방지: 총자산이 initialAsset의 1% 이하면 카드 발동 중지
+        if total_asset > initial_asset * 0.01:
+            active_cards = sorted(
+                [CARDS[cid] for cid in applied_card_ids],
+                key=lambda c: c['priority']
+            )
+
+            for card in active_cards:
+                if card['type'] == 'BUY_ONCE':
+                    continue
+
+                triggered = False
+                if card['type'] == 'BUY_SPLIT':
+                    triggered = True
+                elif card['type'] in ('BUY_ON_CONDITION', 'SELL_ON_CONDITION'):
+                    triggered = _check_condition(card['condition'], spx_change, ndx_change, aapl_change)
+                elif card['type'] == 'BUY_EVERY_N':
+                    triggered = (round_number % 5 == 0)
+
+                if not triggered:
+                    continue
+
+                # maxTrigger 체크
+                if card['max_trigger'] is not None:
+                    count = trigger_map.get(card['id'], 0)
+                    if count >= card['max_trigger']:
+                        continue
+                    trigger_map[card['id']] = count + 1
+
+                # 매도 처리
+                if card['type'] == 'SELL_ON_CONDITION':
+                    if card['ticker'] == '^SPX' and prices['^SPX'] > 0:
+                        sell_shares = shares['^SPX'] * card['ratio']
+                        shares['^SPX'] -= sell_shares
+                        cash += sell_shares * prices['^SPX']
+                    triggered_card_ids.append(card['id'])
+                    continue
+
+                # 현금 부족 스킵 (총자산의 5% 미만)
+                if cash < total_asset * 0.05:
+                    continue
+
+                # 매수 처리
+                amount = cash * card['ratio']
+                price  = prices.get(card['ticker'], 0.0)
+                if price <= 0:
+                    continue
+
+                cash -= amount
+                shares[card['ticker']] += amount / price
+                triggered_card_ids.append(card['id'])
+
+        # 자산 재계산
+        total_asset = cash + sum(shares[t] * prices[t] for t in TICKERS)
+        round_asset = int(total_asset)
+        return_rate = round((total_asset - initial_asset) / initial_asset * 100, 2)
+
+        rounds_result.append({
+            'round':          round_number,
+            'date':           str(spx_curr['Date'])[:10],
+            'roundAsset':     round_asset,
+            'returnRate':     return_rate,
+            'triggeredCards': triggered_card_ids,
+        })
+
+    final = rounds_result[-1] if rounds_result else {}
+    return {
+        'scenario':          'lehman',
+        'start_date':        start_date,
+        'card_selections':   {str(k): v for k, v in card_selections.items()},
+        'initial_asset':     initial_asset,
+        'rounds':            rounds_result,
+        'final_asset':       final.get('roundAsset', initial_asset),
+        'final_return_rate': final.get('returnRate', 0.0),
+    }

--- a/backend/python_simulation/monte_carlo.py
+++ b/backend/python_simulation/monte_carlo.py
@@ -1,0 +1,110 @@
+"""
+몬테카를로 시뮬레이션 — 학습 데이터 생성
+"""
+import os
+import random
+import csv
+import time
+import numpy as np
+from datetime import datetime, timedelta
+from game_logic import run_game, CARDS
+from data_loader import get_price_list
+
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), '..', 'data', 'simulation')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+OUTPUT_PATH = os.path.join(OUTPUT_DIR, 'training_data.csv')
+
+ALL_CARD_IDS       = list(CARDS.keys())   # [1..11]
+CARD_SELECT_ROUNDS = [1, 25, 50, 75]
+SIM_START          = datetime(2007, 9, 1)
+SIM_END            = datetime(2009, 6, 1)  # 100라운드 확보 위해 여유
+
+
+def random_start_date() -> str:
+    """2007-09-01 ~ 2009-06-01 사이 랜덤 날짜"""
+    delta = (SIM_END - SIM_START).days
+    rand_day = SIM_START + timedelta(days=random.randint(0, delta))
+    return rand_day.strftime('%Y-%m-%d')
+
+
+def calc_spx_stats(start_date: str):
+    """SPX 100라운드 수익률 및 변동성 계산"""
+    spx = get_price_list(start_date, '^SPX')
+    if len(spx) < 100:
+        return None, None
+    closes = spx.iloc[:100]['Close'].values
+    total_return = (closes[-1] - closes[0]) / closes[0] * 100
+    daily_returns = np.diff(closes) / closes[:-1] * 100
+    volatility = float(np.std(daily_returns))
+    return round(float(total_return), 4), round(volatility, 4)
+
+
+def run_simulation(n: int = 1000):
+    start_time = time.time()
+    fieldnames = [
+        'sim_id', 'scenario_id', 'start_date',
+        'SPX_Return', 'SPX_Volatility',
+        *[f'Card{i}_Active' for i in range(1, 12)],
+        'Final_Return'
+    ]
+
+    with open(OUTPUT_PATH, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+
+        completed = 0
+        for sim_id in range(1, n + 1):
+            start_date = random_start_date()
+
+            spx_return, spx_vol = calc_spx_stats(start_date)
+            if spx_return is None:
+                continue
+
+            # 카드 선택 (각 라운드마다 11개 중 3개 뽑고 1개 선택)
+            selected_ids = []
+            card_selections = {}
+            for r in CARD_SELECT_ROUNDS:
+                pool = [c for c in ALL_CARD_IDS if c not in selected_ids]
+                if len(pool) < 3:
+                    pool = ALL_CARD_IDS.copy()
+                options = random.sample(pool, min(3, len(pool)))
+                chosen  = random.choice(options)
+                card_selections[r] = chosen
+                selected_ids.append(chosen)
+
+            try:
+                result = run_game(start_date, card_selections)
+            except Exception:
+                continue
+
+            card_active = {f'Card{i}_Active': (1 if i in selected_ids else 0) for i in range(1, 12)}
+
+            row = {
+                'sim_id':         sim_id,
+                'scenario_id':    'lehman',
+                'start_date':     start_date,
+                'SPX_Return':     spx_return,
+                'SPX_Volatility': spx_vol,
+                **card_active,
+                'Final_Return':   result['final_return_rate'],
+            }
+            writer.writerow(row)
+            completed += 1
+
+            if sim_id % 100 == 0:
+                elapsed = time.time() - start_time
+                est_total = elapsed / sim_id * n
+                print(f'  {sim_id}/{n} 완료 ({elapsed:.0f}초 경과, 예상 총 {est_total:.0f}초)')
+
+    elapsed = time.time() - start_time
+    print(f'\n시뮬레이션 완료: {OUTPUT_PATH}')
+    print(f'총 시간: {elapsed:.1f}초  /  1회 평균: {elapsed/max(completed,1)*1000:.1f}ms')
+    print(f'1만 회 예상: {elapsed/max(completed,1)*10000:.0f}초')
+
+
+if __name__ == '__main__':
+    try:
+        n = int(input('시뮬레이션 횟수 입력 (예: 1000): ') or 1000)
+    except ValueError:
+        n = 1000
+    run_simulation(n)

--- a/backend/python_simulation/requirements.txt
+++ b/backend/python_simulation/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+numpy

--- a/backend/python_simulation/validator.py
+++ b/backend/python_simulation/validator.py
@@ -1,0 +1,77 @@
+"""
+검증 모드: Python 결과 vs Java 결과 비교
+"""
+import json
+import os
+from game_logic import run_game
+
+OUTPUT_DIR = os.path.join(os.path.dirname(__file__), '..', 'data', 'simulation')
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def run_validation(start_date: str, card_selections: dict,
+                   initial_asset: int = 10_000_000,
+                   output_file: str = 'result_python.json') -> dict:
+    """
+    사용자 지정 입력으로 게임 실행 후 JSON 저장
+    :param start_date: "2008-09-02"
+    :param card_selections: {1: 1, 25: 2, 50: 3, 75: 4}
+    :param output_file: 저장할 파일명
+    """
+    result = run_game(start_date, card_selections, initial_asset)
+    path = os.path.join(OUTPUT_DIR, output_file)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+    print(f'저장 완료: {path}')
+    return result
+
+
+def compare_results(java_file: str, python_file: str, tolerance: float = 1.0) -> bool:
+    """Java 결과와 Python 결과 비교"""
+    with open(java_file, encoding='utf-8') as f1:
+        java = json.load(f1)
+    with open(python_file, encoding='utf-8') as f2:
+        python = json.load(f2)
+
+    mismatches = []
+    for j, p in zip(java['rounds'], python['rounds']):
+        if abs(j['roundAsset'] - p['roundAsset']) > tolerance:
+            mismatches.append({
+                'round': j['round'], 'field': 'roundAsset',
+                'java': j['roundAsset'], 'python': p['roundAsset']
+            })
+        if sorted(j['triggeredCards']) != sorted(p['triggeredCards']):
+            mismatches.append({
+                'round': j['round'], 'field': 'triggeredCards',
+                'java': j['triggeredCards'], 'python': p['triggeredCards']
+            })
+
+    if mismatches:
+        print(f'❌ {len(mismatches)}건 불일치 발견')
+        for m in mismatches[:10]:
+            print(f"  Round {m['round']} {m['field']}: java={m['java']}, python={m['python']}")
+        return False
+
+    print('✅ 모든 라운드 결과 일치')
+    return True
+
+
+# 검증 시나리오 5개
+VALIDATION_CASES = [
+    {'name': 'test1', 'start_date': '2008-09-02', 'cards': {1: 1,  25: 2,  50: 3,  75: 4}},
+    {'name': 'test2', 'start_date': '2008-09-02', 'cards': {1: 8,  25: 1,  50: 2,  75: 3}},
+    {'name': 'test3', 'start_date': '2008-09-02', 'cards': {1: 11, 25: 11, 50: 11, 75: 11}},
+    {'name': 'test4', 'start_date': '2008-09-02', 'cards': {1: 9,  25: 9,  50: 9,  75: 9}},
+    {'name': 'test5', 'start_date': '2008-10-15', 'cards': {1: 1,  25: 7,  50: 5,  75: 10}},
+]
+
+if __name__ == '__main__':
+    print('=== 검증 시나리오 실행 ===\n')
+    for case in VALIDATION_CASES:
+        print(f"[{case['name']}] start={case['start_date']} cards={case['cards']}")
+        result = run_validation(
+            case['start_date'],
+            case['cards'],
+            output_file=f"result_python_{case['name']}.json"
+        )
+        print(f"  최종 자산: {result['final_asset']:,}원  수익률: {result['final_return_rate']}%\n")

--- a/backend/python_simulation/validator.py
+++ b/backend/python_simulation/validator.py
@@ -3,29 +3,60 @@
 """
 import json
 import os
+import requests
 from game_logic import run_game
 
 OUTPUT_DIR = os.path.join(os.path.dirname(__file__), '..', 'data', 'simulation')
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
+JAVA_BASE_URL = "http://localhost:8080"
 
-def run_validation(start_date: str, card_selections: dict,
-                   initial_asset: int = 10_000_000,
-                   output_file: str = 'result_python.json') -> dict:
+# =============================================
+# Python 검증 모드
+# =============================================
+def run_python_validation(start_date: str, card_selections: dict,
+                          output_file: str = 'result_python.json') -> dict:
     """
-    사용자 지정 입력으로 게임 실행 후 JSON 저장
+    Python 게임 로직 실행 후 JSON 저장
     :param start_date: "2008-09-02"
     :param card_selections: {1: 1, 25: 2, 50: 3, 75: 4}
-    :param output_file: 저장할 파일명
     """
-    result = run_game(start_date, card_selections, initial_asset)
+    result = run_game(start_date, card_selections)
     path = os.path.join(OUTPUT_DIR, output_file)
     with open(path, 'w', encoding='utf-8') as f:
         json.dump(result, f, ensure_ascii=False, indent=2)
-    print(f'저장 완료: {path}')
+    print(f'Python 저장 완료: {path}')
     return result
 
 
+# =============================================
+# Java API 호출 검증 모드
+# =============================================
+def run_java_validation(start_date: str, card_selections: dict,
+                        output_file: str = 'result_java.json') -> dict:
+    """
+    Java /game/validate API 호출 후 JSON 저장
+    :param start_date: "2008-09-02"
+    :param card_selections: {1: 1, 25: 2, 50: 3, 75: 4}
+    """
+    payload = {
+        "startDate": start_date,
+        "cardSelections": {str(k): v for k, v in card_selections.items()}
+    }
+    resp = requests.post(f"{JAVA_BASE_URL}/game/validate", json=payload)
+    resp.raise_for_status()
+    result = resp.json().get("data", resp.json())
+
+    path = os.path.join(OUTPUT_DIR, output_file)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+    print(f'Java 저장 완료: {path}')
+    return result
+
+
+# =============================================
+# 비교 스크립트
+# =============================================
 def compare_results(java_file: str, python_file: str, tolerance: float = 1.0) -> bool:
     """Java 결과와 Python 결과 비교"""
     with open(java_file, encoding='utf-8') as f1:
@@ -56,7 +87,9 @@ def compare_results(java_file: str, python_file: str, tolerance: float = 1.0) ->
     return True
 
 
+# =============================================
 # 검증 시나리오 5개
+# =============================================
 VALIDATION_CASES = [
     {'name': 'test1', 'start_date': '2008-09-02', 'cards': {1: 1,  25: 2,  50: 3,  75: 4}},
     {'name': 'test2', 'start_date': '2008-09-02', 'cards': {1: 8,  25: 1,  50: 2,  75: 3}},
@@ -66,12 +99,40 @@ VALIDATION_CASES = [
 ]
 
 if __name__ == '__main__':
-    print('=== 검증 시나리오 실행 ===\n')
+    import sys
+    mode = sys.argv[1] if len(sys.argv) > 1 else 'python'
+
+    print(f'=== 검증 시나리오 실행 (mode={mode}) ===\n')
+
     for case in VALIDATION_CASES:
-        print(f"[{case['name']}] start={case['start_date']} cards={case['cards']}")
-        result = run_validation(
-            case['start_date'],
-            case['cards'],
-            output_file=f"result_python_{case['name']}.json"
-        )
-        print(f"  최종 자산: {result['final_asset']:,}원  수익률: {result['final_return_rate']}%\n")
+        name = case['name']
+        print(f"[{name}] start={case['start_date']} cards={case['cards']}")
+
+        if mode == 'python':
+            # Python 결과 생성
+            result = run_python_validation(
+                case['start_date'], case['cards'],
+                output_file=f'result_python_{name}.json'
+            )
+            print(f"  최종 자산: {result['final_asset']:,}원  수익률: {result['final_return_rate']}%\n")
+
+        elif mode == 'java':
+            # Java API 결과 생성 (서버 실행 중이어야 함)
+            result = run_java_validation(
+                case['start_date'], case['cards'],
+                output_file=f'result_java_{name}.json'
+            )
+            print(f"  최종 자산: {result.get('final_asset', '?'):,}  수익률: {result.get('final_return_rate', '?')}%\n")
+
+        elif mode == 'compare':
+            # Python vs Java 비교
+            java_path   = os.path.join(OUTPUT_DIR, f'result_java_{name}.json')
+            python_path = os.path.join(OUTPUT_DIR, f'result_python_{name}.json')
+            if not os.path.exists(java_path):
+                print(f'  Java 파일 없음: {java_path} (먼저 java 모드 실행)\n')
+                continue
+            if not os.path.exists(python_path):
+                print(f'  Python 파일 없음: {python_path} (먼저 python 모드 실행)\n')
+                continue
+            compare_results(java_path, python_path)
+            print()

--- a/backend/src/main/java/com/capstone/survival/controller/GameController.java
+++ b/backend/src/main/java/com/capstone/survival/controller/GameController.java
@@ -7,6 +7,7 @@ import com.capstone.survival.service.GameService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -42,5 +43,19 @@ public class GameController {
         return ApiResponse.ok(
                 gameService.selectCard(sessionId, round, cardId)
         );
+    }
+
+    // POST /game/validate (Python 결과와 비교용 검증 엔드포인트)
+    @PostMapping("/validate")
+    public ApiResponse<?> validateGame(@RequestBody Map<String, Object> request) {
+        String startDate = (String) request.get("startDate");
+
+        // cardSelections: {"1": 1, "25": 2, "50": 3, "75": 4}
+        @SuppressWarnings("unchecked")
+        Map<String, Object> rawSelections = (Map<String, Object>) request.get("cardSelections");
+        Map<Integer, Integer> cardSelections = new LinkedHashMap<>();
+        rawSelections.forEach((k, v) -> cardSelections.put(Integer.parseInt(k), (Integer) v));
+
+        return ApiResponse.ok(gameService.validateGame(startDate, cardSelections));
     }
 }

--- a/backend/src/main/java/com/capstone/survival/service/GameService.java
+++ b/backend/src/main/java/com/capstone/survival/service/GameService.java
@@ -26,6 +26,7 @@ public class GameService {
 
     private static final List<Integer> CARD_SELECT_ROUNDS = List.of(1, 25, 50, 75);
     private static final List<Integer> ALL_CARD_IDS = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+    private static final long INITIAL_ASSET = 10_000_000L;
 
     // =============================================
     // 게임 시작
@@ -53,7 +54,6 @@ public class GameService {
         );
         sessionRepository.save(session);
 
-        // 1라운드 데이터
         StockPrice first = priceList.get(0);
         Map<String, Object> priceData = new LinkedHashMap<>();
         priceData.put("ticker", first.getTicker());
@@ -72,7 +72,7 @@ public class GameService {
         response.put("sessionId", sessionId);
         response.put("scenarioTitle", scenario.getTitle());
         response.put("totalRounds", 100);
-        response.put("initialAsset", 10_000_000L);
+        response.put("initialAsset", INITIAL_ASSET);
         response.put("cardSelectRounds", CARD_SELECT_ROUNDS);
         response.put("firstCardOptions", getRandomCards(new ArrayList<>()));
         response.put("rounds", List.of(firstRound));
@@ -92,19 +92,16 @@ public class GameService {
         Card card = cardRepository.findById(cardId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카드입니다"));
 
-        // 중복 카드 체크
         List<Integer> appliedCardIds = getAppliedCardIds(session);
         if (appliedCardIds.contains(cardId)) {
             throw new IllegalArgumentException("이미 선택한 카드입니다");
         }
 
-        // 적용 카드 목록 업데이트
         appliedCardIds.add(cardId);
         String newAppliedCards = appliedCardIds.stream()
                 .map(String::valueOf)
                 .collect(Collectors.joining(","));
 
-        // BUY_ONCE 즉시 매수 처리
         double spxShares = session.getSpxShares();
         double ndxShares = session.getNdxShares();
         double xauusdShares = session.getXauusdShares();
@@ -126,7 +123,6 @@ public class GameService {
             else if ("TLT".equals(card.getTicker()))   tltShares += newShares;
         }
 
-        // 다음 증강 라운드
         Integer nextEventRound = CARD_SELECT_ROUNDS.stream()
                 .filter(r -> r > round)
                 .findFirst()
@@ -134,7 +130,6 @@ public class GameService {
 
         int endRound = nextEventRound != null ? nextEventRound - 1 : 100;
 
-        // 라운드 계산
         Map<String, Object> calcResult = calculateRounds(
                 session, round, endRound,
                 cash, spxShares, ndxShares, xauusdShares,
@@ -152,7 +147,6 @@ public class GameService {
         double finalTlt = (double) calcResult.get("finalTlt");
         String finalTriggerCount = (String) calcResult.get("triggerCount");
 
-        // 세션 업데이트
         session.update(
                 finalCash, finalSpx, finalNdx, finalXauusd,
                 finalUso, finalAapl, finalTlt,
@@ -160,7 +154,6 @@ public class GameService {
         );
         sessionRepository.save(session);
 
-        // 다음 카드 옵션
         List<Integer> nextCardOptions = nextEventRound != null
                 ? getRandomCards(appliedCardIds)
                 : null;
@@ -175,30 +168,111 @@ public class GameService {
     }
 
     // =============================================
+    // 검증용 게임 실행 (DB 저장 없이 start_date 직접 지정)
+    // Python 결과와 1:1 비교용
+    // =============================================
+    public Map<String, Object> validateGame(String startDate, Map<Integer, Integer> cardSelections) {
+
+        // 임시 세션 생성 (DB 저장 안 함)
+        GameSession session = new GameSession(
+                "validate", 1, "lehman", "^SPX", startDate
+        );
+
+        long cash = INITIAL_ASSET;
+        double spxShares = 0, ndxShares = 0, xauusdShares = 0;
+        double usoShares = 0, aaplShares = 0, tltShares = 0;
+        List<Integer> appliedCardIds = new ArrayList<>();
+        String triggerCount = "";
+
+        List<Map<String, Object>> allRounds = new ArrayList<>();
+
+        // 카드 선택 라운드 순서대로 처리
+        List<Integer> sortedRounds = new ArrayList<>(cardSelections.keySet());
+        Collections.sort(sortedRounds);
+
+        for (int idx = 0; idx < sortedRounds.size(); idx++) {
+            int selectRound = sortedRounds.get(idx);
+            int cardId = cardSelections.get(selectRound);
+
+            appliedCardIds.add(cardId);
+            Card card = cardRepository.findById(cardId)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카드: " + cardId));
+
+            // BUY_ONCE 즉시 매수
+            if ("BUY_ONCE".equals(card.getType())) {
+                double price = getPriceAtRound(session, selectRound, card.getTicker());
+                if (price > 0) {
+                    double buyAmount = cash * card.getRatio();
+                    cash -= (long) buyAmount;
+                    double shares = buyAmount / price;
+                    if ("^SPX".equals(card.getTicker()))       spxShares    += shares;
+                    else if ("^NDX".equals(card.getTicker()))   ndxShares    += shares;
+                    else if ("XAUUSD".equals(card.getTicker())) xauusdShares += shares;
+                    else if ("USO".equals(card.getTicker()))    usoShares    += shares;
+                    else if ("AAPL".equals(card.getTicker()))   aaplShares   += shares;
+                    else if ("TLT".equals(card.getTicker()))    tltShares    += shares;
+                }
+            }
+
+            // 다음 선택 라운드 직전까지 계산
+            int endRound = (idx + 1 < sortedRounds.size())
+                    ? sortedRounds.get(idx + 1) - 1
+                    : 100;
+
+            Map<String, Object> calcResult = calculateRounds(
+                    session, selectRound, endRound,
+                    cash, spxShares, ndxShares, xauusdShares,
+                    usoShares, aaplShares, tltShares,
+                    new ArrayList<>(appliedCardIds), triggerCount
+            );
+
+            List<Map<String, Object>> segmentRounds = (List<Map<String, Object>>) calcResult.get("rounds");
+            allRounds.addAll(segmentRounds);
+
+            // 다음 구간을 위해 상태 업데이트
+            cash         = (long)   calcResult.get("finalCash");
+            spxShares    = (double) calcResult.get("finalSpx");
+            ndxShares    = (double) calcResult.get("finalNdx");
+            xauusdShares = (double) calcResult.get("finalXauusd");
+            usoShares    = (double) calcResult.get("finalUso");
+            aaplShares   = (double) calcResult.get("finalAapl");
+            tltShares    = (double) calcResult.get("finalTlt");
+            triggerCount = (String) calcResult.get("triggerCount");
+        }
+
+        Map<String, Object> lastRound = allRounds.isEmpty() ? new HashMap<>() : allRounds.get(allRounds.size() - 1);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("scenario", "lehman");
+        result.put("start_date", startDate);
+        result.put("card_selections", cardSelections);
+        result.put("initial_asset", INITIAL_ASSET);
+        result.put("rounds", allRounds);
+        result.put("final_asset", lastRound.getOrDefault("roundAsset", INITIAL_ASSET));
+        result.put("final_return_rate", lastRound.getOrDefault("returnRate", 0.0));
+        return result;
+    }
+
+    // =============================================
     // 라운드별 자산 계산
     // =============================================
     private Map<String, Object> calculateRounds(
             GameSession session, int startRound, int endRound,
             long cash, double spxShares, double ndxShares, double xauusdShares,
-            double  usoShares, double aaplShares, double tltShares,
+            double usoShares, double aaplShares, double tltShares,
             List<Integer> appliedCardIds, String triggerCountStr) {
 
-        // 주가 데이터 로드
-        List<StockPrice> spxList = loadPriceList(session, "^SPX");
-        List<StockPrice> ndxList = loadPriceList(session, "^NDX");
+        List<StockPrice> spxList    = loadPriceList(session, "^SPX");
+        List<StockPrice> ndxList    = loadPriceList(session, "^NDX");
         List<StockPrice> xauusdList = loadPriceList(session, "XAUUSD");
-        List<StockPrice> usoList = loadPriceList(session, "USO");
-        List<StockPrice> aaplList = loadPriceList(session, "AAPL");
-        List<StockPrice> tltList = loadPriceList(session, "TLT");
+        List<StockPrice> usoList    = loadPriceList(session, "USO");
+        List<StockPrice> aaplList   = loadPriceList(session, "AAPL");
+        List<StockPrice> tltList    = loadPriceList(session, "TLT");
 
-
-        // 적용된 카드 목록
         List<Card> appliedCards = cardRepository.findAllById(appliedCardIds);
         appliedCards.sort(Comparator.comparing(Card::getPriority));
 
-        // 발동 횟수 파싱
         Map<Integer, Integer> triggerMap = parseTriggerCount(triggerCountStr);
-
         List<Map<String, Object>> rounds = new ArrayList<>();
 
         for (int i = startRound - 1; i < endRound; i++) {
@@ -206,40 +280,36 @@ public class GameService {
 
             int roundNumber = i + 1;
 
-            StockPrice spxCurrent = spxList.get(i);
-            StockPrice spxPrev = i > 0 ? spxList.get(i - 1) : null;
-            StockPrice ndxCurrent = i < ndxList.size() ? ndxList.get(i) : null;
-            StockPrice ndxPrev = (i > 0 && i < ndxList.size()) ? ndxList.get(i - 1) : null;
-            StockPrice xauusdCurrent = i < xauusdList.size() ? xauusdList.get(i) : null;
-            StockPrice usoCurrent = i < usoList.size() ? usoList.get(i) : null;
-            StockPrice usoPrev = (i > 0 && i < usoList.size()) ? usoList.get(i - 1) : null;
-            StockPrice aaplCurrent = i < aaplList.size() ? aaplList.get(i) : null;
-            StockPrice aaplPrev = (i > 0 && i < aaplList.size()) ? aaplList.get(i - 1) : null;
-            StockPrice tltCurrent = i < tltList.size() ? tltList.get(i) : null;
+            StockPrice spxCurrent   = spxList.get(i);
+            StockPrice spxPrev      = i > 0 ? spxList.get(i - 1) : null;
+            StockPrice ndxCurrent   = i < ndxList.size()    ? ndxList.get(i)    : null;
+            StockPrice ndxPrev      = (i > 0 && i < ndxList.size()) ? ndxList.get(i - 1) : null;
+            StockPrice xauusdCurrent= i < xauusdList.size() ? xauusdList.get(i) : null;
+            StockPrice usoCurrent   = i < usoList.size()    ? usoList.get(i)    : null;
+            StockPrice usoPrev      = (i > 0 && i < usoList.size())  ? usoList.get(i - 1)  : null;
+            StockPrice aaplCurrent  = i < aaplList.size()   ? aaplList.get(i)   : null;
+            StockPrice aaplPrev     = (i > 0 && i < aaplList.size()) ? aaplList.get(i - 1) : null;
+            StockPrice tltCurrent   = i < tltList.size()    ? tltList.get(i)    : null;
 
-            // 등락률 계산
-            double spxChangeRate = calcChangeRate(spxPrev, spxCurrent);
-            double ndxChangeRate = calcChangeRate(ndxPrev, ndxCurrent);
+            double spxChangeRate  = calcChangeRate(spxPrev, spxCurrent);
+            double ndxChangeRate  = calcChangeRate(ndxPrev, ndxCurrent);
             double aaplChangeRate = calcChangeRate(aaplPrev, aaplCurrent);
 
-            // 자산 계산 (파산 방지 체크용)
-            double spxValue = spxShares * spxCurrent.getClose();
-            double ndxValue = ndxCurrent != null ? ndxShares * ndxCurrent.getClose() : 0;
+            double spxValue    = spxShares    * spxCurrent.getClose();
+            double ndxValue    = ndxCurrent    != null ? ndxShares    * ndxCurrent.getClose()    : 0;
             double xauusdValue = xauusdCurrent != null ? xauusdShares * xauusdCurrent.getClose() : 0;
-            double usoValue = usoCurrent != null ? usoShares * usoCurrent.getClose() : 0;
-            double aaplValue = aaplCurrent != null ? aaplShares * aaplCurrent.getClose() : 0;
-            double tltValue = tltCurrent != null ? tltShares * tltCurrent.getClose() : 0;
-            long totalAsset = cash + (long) (spxValue + ndxValue + xauusdValue + usoValue + aaplValue + tltValue);
+            double usoValue    = usoCurrent    != null ? usoShares    * usoCurrent.getClose()    : 0;
+            double aaplValue   = aaplCurrent   != null ? aaplShares   * aaplCurrent.getClose()   : 0;
+            double tltValue    = tltCurrent    != null ? tltShares    * tltCurrent.getClose()    : 0;
+            long totalAsset = cash + (long)(spxValue + ndxValue + xauusdValue + usoValue + aaplValue + tltValue);
 
             List<Integer> triggeredCardIds = new ArrayList<>();
 
-            if (totalAsset > session.getInitialAsset() * 0.01) { // 파산 방지 체크
-
+            if (totalAsset > session.getInitialAsset() * 0.01) {
                 for (Card card : appliedCards) {
                     if ("BUY_ONCE".equals(card.getType())) continue;
 
                     boolean triggered = false;
-
                     if ("BUY_SPLIT".equals(card.getType())) {
                         triggered = true;
                     } else if ("BUY_ON_CONDITION".equals(card.getType())) {
@@ -252,127 +322,93 @@ public class GameService {
 
                     if (!triggered) continue;
 
-                    // maxTrigger 체크
                     if (card.getMaxTrigger() != null) {
                         int count = triggerMap.getOrDefault(card.getId(), 0);
                         if (count >= card.getMaxTrigger()) continue;
                         triggerMap.put(card.getId(), count + 1);
                     }
 
-                    // 매도 카드 처리 (SELL_ON_CONDITION)
                     if ("SELL_ON_CONDITION".equals(card.getType())) {
-                        double sellShares = 0;
-                        double sellPrice = 0;
                         if ("^SPX".equals(card.getTicker())) {
-                            sellShares = spxShares * card.getRatio();
-                            sellPrice = spxCurrent.getClose();
+                            double sellShares = spxShares * card.getRatio();
+                            cash += (long)(sellShares * spxCurrent.getClose());
                             spxShares -= sellShares;
                         }
-                        cash += (long) (sellShares * sellPrice);
                         triggeredCardIds.add(card.getId());
                         continue;
                     }
 
-                    // 현금 부족 체크 (총자산의 5% 미만이면 매수 스킵)
                     if (cash < totalAsset * 0.05) continue;
 
-                    // 매수 금액 계산 및 실행
                     double amount = cash * card.getRatio();
-                    double price = getTickerPrice(card.getTicker(), spxCurrent, ndxCurrent, xauusdCurrent, usoCurrent, aaplCurrent, tltCurrent);
+                    double price  = getTickerPrice(card.getTicker(), spxCurrent, ndxCurrent, xauusdCurrent, usoCurrent, aaplCurrent, tltCurrent);
                     if (price <= 0) continue;
 
                     cash -= (long) amount;
                     double shares = amount / price;
-                    if ("^SPX".equals(card.getTicker())) spxShares += shares;
-                    else if ("^NDX".equals(card.getTicker())) ndxShares += shares;
+                    if ("^SPX".equals(card.getTicker()))       spxShares    += shares;
+                    else if ("^NDX".equals(card.getTicker()))   ndxShares    += shares;
                     else if ("XAUUSD".equals(card.getTicker())) xauusdShares += shares;
-                    else if ("USO".equals(card.getTicker())) usoShares += shares;
-                    else if ("AAPL".equals(card.getTicker())) aaplShares += shares;
-                    else if ("TLT".equals(card.getTicker())) tltShares += shares;
+                    else if ("USO".equals(card.getTicker()))    usoShares    += shares;
+                    else if ("AAPL".equals(card.getTicker()))   aaplShares   += shares;
+                    else if ("TLT".equals(card.getTicker()))    tltShares    += shares;
 
                     triggeredCardIds.add(card.getId());
                 }
             }
 
-            // 자산 재계산
-            spxValue = spxShares * spxCurrent.getClose();
-            ndxValue = ndxCurrent != null ? ndxShares * ndxCurrent.getClose() : 0;
+            spxValue    = spxShares    * spxCurrent.getClose();
+            ndxValue    = ndxCurrent    != null ? ndxShares    * ndxCurrent.getClose()    : 0;
             xauusdValue = xauusdCurrent != null ? xauusdShares * xauusdCurrent.getClose() : 0;
-            usoValue = usoCurrent != null ? usoShares * usoCurrent.getClose() : 0;
-            aaplValue = aaplCurrent != null ? aaplShares * aaplCurrent.getClose() : 0;
-            tltValue = tltCurrent != null ? tltShares * tltCurrent.getClose() : 0;
-            long roundAsset = cash + (long) (spxValue + ndxValue + xauusdValue + usoValue + aaplValue + tltValue);
-            double returnRate = (double) (roundAsset - session.getInitialAsset()) / session.getInitialAsset() * 100;
+            usoValue    = usoCurrent    != null ? usoShares    * usoCurrent.getClose()    : 0;
+            aaplValue   = aaplCurrent   != null ? aaplShares   * aaplCurrent.getClose()   : 0;
+            tltValue    = tltCurrent    != null ? tltShares    * tltCurrent.getClose()    : 0;
+            long roundAsset = cash + (long)(spxValue + ndxValue + xauusdValue + usoValue + aaplValue + tltValue);
+            double returnRate = (double)(roundAsset - session.getInitialAsset()) / session.getInitialAsset() * 100;
 
-            // priceData 구성 (보유 종목만)
             List<Map<String, Object>> priceDataList = new ArrayList<>();
-
             Map<String, Object> spxData = new LinkedHashMap<>();
-            spxData.put("ticker", "^SPX");
-            spxData.put("open", spxCurrent.getOpen());
-            spxData.put("close", spxCurrent.getClose());
-            spxData.put("high", spxCurrent.getHigh());
-            spxData.put("low", spxCurrent.getLow());
-            spxData.put("changeRate", spxChangeRate);
+            spxData.put("ticker", "^SPX"); spxData.put("open", spxCurrent.getOpen());
+            spxData.put("close", spxCurrent.getClose()); spxData.put("high", spxCurrent.getHigh());
+            spxData.put("low", spxCurrent.getLow()); spxData.put("changeRate", spxChangeRate);
             priceDataList.add(spxData);
 
             if (ndxShares > 0 && ndxCurrent != null) {
                 Map<String, Object> ndxData = new LinkedHashMap<>();
-                ndxData.put("ticker", "^NDX");
-                ndxData.put("open", ndxCurrent.getOpen());
-                ndxData.put("close", ndxCurrent.getClose());
-                ndxData.put("high", ndxCurrent.getHigh());
-                ndxData.put("low", ndxCurrent.getLow());
-                ndxData.put("changeRate", ndxChangeRate);
+                ndxData.put("ticker", "^NDX"); ndxData.put("open", ndxCurrent.getOpen());
+                ndxData.put("close", ndxCurrent.getClose()); ndxData.put("high", ndxCurrent.getHigh());
+                ndxData.put("low", ndxCurrent.getLow()); ndxData.put("changeRate", ndxChangeRate);
                 priceDataList.add(ndxData);
             }
-
             if (xauusdShares > 0 && xauusdCurrent != null) {
-                double xauusdChangeRate = calcChangeRate(
-                        i > 0 && i < xauusdList.size() ? xauusdList.get(i - 1) : null, xauusdCurrent);
+                double xauusdChangeRate = calcChangeRate(i > 0 && i < xauusdList.size() ? xauusdList.get(i-1) : null, xauusdCurrent);
                 Map<String, Object> xauusdData = new LinkedHashMap<>();
-                xauusdData.put("ticker", "XAUUSD");
-                xauusdData.put("open", xauusdCurrent.getOpen());
-                xauusdData.put("close", xauusdCurrent.getClose());
-                xauusdData.put("high", xauusdCurrent.getHigh());
-                xauusdData.put("low", xauusdCurrent.getLow());
-                xauusdData.put("changeRate", xauusdChangeRate);
+                xauusdData.put("ticker", "XAUUSD"); xauusdData.put("open", xauusdCurrent.getOpen());
+                xauusdData.put("close", xauusdCurrent.getClose()); xauusdData.put("high", xauusdCurrent.getHigh());
+                xauusdData.put("low", xauusdCurrent.getLow()); xauusdData.put("changeRate", xauusdChangeRate);
                 priceDataList.add(xauusdData);
             }
-
             if (usoShares > 0 && usoCurrent != null) {
                 double usoChangeRate = calcChangeRate(usoPrev, usoCurrent);
                 Map<String, Object> usoData = new LinkedHashMap<>();
-                usoData.put("ticker", "USO");
-                usoData.put("open", usoCurrent.getOpen());
-                usoData.put("close", usoCurrent.getClose());
-                usoData.put("high", usoCurrent.getHigh());
-                usoData.put("low", usoCurrent.getLow());
-                usoData.put("changeRate", usoChangeRate);
+                usoData.put("ticker", "USO"); usoData.put("open", usoCurrent.getOpen());
+                usoData.put("close", usoCurrent.getClose()); usoData.put("high", usoCurrent.getHigh());
+                usoData.put("low", usoCurrent.getLow()); usoData.put("changeRate", usoChangeRate);
                 priceDataList.add(usoData);
             }
-
             if (aaplShares > 0 && aaplCurrent != null) {
                 Map<String, Object> aaplData = new LinkedHashMap<>();
-                aaplData.put("ticker", "AAPL");
-                aaplData.put("open", aaplCurrent.getOpen());
-                aaplData.put("close", aaplCurrent.getClose());
-                aaplData.put("high", aaplCurrent.getHigh());
-                aaplData.put("low", aaplCurrent.getLow());
-                aaplData.put("changeRate", aaplChangeRate);
+                aaplData.put("ticker", "AAPL"); aaplData.put("open", aaplCurrent.getOpen());
+                aaplData.put("close", aaplCurrent.getClose()); aaplData.put("high", aaplCurrent.getHigh());
+                aaplData.put("low", aaplCurrent.getLow()); aaplData.put("changeRate", aaplChangeRate);
                 priceDataList.add(aaplData);
             }
-
             if (tltShares > 0 && tltCurrent != null) {
-                double tltChangeRate = calcChangeRate(
-                        i > 0 && i < tltList.size() ? tltList.get(i - 1) : null, tltCurrent);
+                double tltChangeRate = calcChangeRate(i > 0 && i < tltList.size() ? tltList.get(i-1) : null, tltCurrent);
                 Map<String, Object> tltData = new LinkedHashMap<>();
-                tltData.put("ticker", "TLT");
-                tltData.put("open", tltCurrent.getOpen());
-                tltData.put("close", tltCurrent.getClose());
-                tltData.put("high", tltCurrent.getHigh());
-                tltData.put("low", tltCurrent.getLow());
-                tltData.put("changeRate", tltChangeRate);
+                tltData.put("ticker", "TLT"); tltData.put("open", tltCurrent.getOpen());
+                tltData.put("close", tltCurrent.getClose()); tltData.put("high", tltCurrent.getHigh());
+                tltData.put("low", tltCurrent.getLow()); tltData.put("changeRate", tltChangeRate);
                 priceDataList.add(tltData);
             }
 
@@ -386,7 +422,6 @@ public class GameService {
             rounds.add(roundMap);
         }
 
-// 결과 반환
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("rounds", rounds);
         result.put("finalCash", cash);
@@ -403,32 +438,28 @@ public class GameService {
     // =============================================
     // 유틸 메서드
     // =============================================
+    private boolean checkCondition(String condition,
+            double spxChangeRate, double ndxChangeRate, double aaplChangeRate) {
+        return switch (condition) {
+            case "SPX_CHANGE <= -3"  -> spxChangeRate  <= -3;
+            case "SPX_CHANGE <= -5"  -> spxChangeRate  <= -5;
+            case "SPX_CHANGE >= 3"   -> spxChangeRate  >= 3;
+            case "NDX_CHANGE >= 2"   -> ndxChangeRate  >= 2;
+            case "NDX_CHANGE <= -4"  -> ndxChangeRate  <= -4;
+            case "AAPL_CHANGE <= -5" -> aaplChangeRate <= -5;
+            default -> false;
+        };
+    }
 
-    // 조건 체크
-        private boolean checkCondition(String condition,
-        double spxChangeRate, double ndxChangeRate, double aaplChangeRate) {
-            return switch (condition) {
-                case "SPX_CHANGE <= -3"  -> spxChangeRate  <= -3;
-                case "SPX_CHANGE <= -5"  -> spxChangeRate  <= -5;
-                case "SPX_CHANGE >= 3"   -> spxChangeRate  >= 3;
-                case "NDX_CHANGE >= 2"   -> ndxChangeRate  >= 2;
-                case "NDX_CHANGE <= -4"  -> ndxChangeRate  <= -4;
-                case "AAPL_CHANGE <= -5" -> aaplChangeRate <= -5;
-                default -> false;
-            };
-        }
-
-    // 등락률 계산
     private double calcChangeRate(StockPrice prev, StockPrice current) {
         if (prev == null || current == null || prev.getClose() <= 0) return 0.0;
         double rate = (current.getClose() - prev.getClose()) / prev.getClose() * 100;
         return Math.round(rate * 100.0) / 100.0;
     }
 
-    // ticker별 현재가 반환
     private double getTickerPrice(String ticker,
-                                  StockPrice spx, StockPrice ndx, StockPrice xauusd,
-                                  StockPrice uso, StockPrice aapl, StockPrice tlt) {
+            StockPrice spx, StockPrice ndx, StockPrice xauusd,
+            StockPrice uso, StockPrice aapl, StockPrice tlt) {
         return switch (ticker) {
             case "^SPX"   -> spx    != null ? spx.getClose()    : 0;
             case "^NDX"   -> ndx    != null ? ndx.getClose()    : 0;
@@ -440,9 +471,6 @@ public class GameService {
         };
     }
 
-
-
-    // 주가 데이터 로드
     private List<StockPrice> loadPriceList(GameSession session, String ticker) {
         return stockPriceRepository
                 .findByTickerAndTradeDateGreaterThanEqualOrderByTradeDate(
@@ -450,14 +478,12 @@ public class GameService {
                 );
     }
 
-    // 특정 라운드 종가 조회
     private double getPriceAtRound(GameSession session, int round, String ticker) {
         List<StockPrice> list = loadPriceList(session, ticker);
         if (round - 1 >= list.size()) return 0;
         return list.get(round - 1).getClose();
     }
 
-    // 랜덤 카드 3개 뽑기 (이미 선택한 카드 제외)
     private List<Integer> getRandomCards(List<Integer> appliedCardIds) {
         List<Integer> available = new ArrayList<>(ALL_CARD_IDS);
         available.removeAll(appliedCardIds);
@@ -466,10 +492,8 @@ public class GameService {
         return new ArrayList<>(available.subList(0, count));
     }
 
-    // 적용된 카드 ID 목록 파싱
     private List<Integer> getAppliedCardIds(GameSession session) {
-        if (session.getAppliedCards() == null
-                || session.getAppliedCards().isEmpty()) {
+        if (session.getAppliedCards() == null || session.getAppliedCards().isEmpty()) {
             return new ArrayList<>();
         }
         return Arrays.stream(session.getAppliedCards().split(","))
@@ -477,7 +501,6 @@ public class GameService {
                 .collect(Collectors.toList());
     }
 
-    // 발동 횟수 파싱 "6:2,3:1" → {6: 2, 3: 1}
     private Map<Integer, Integer> parseTriggerCount(String str) {
         Map<Integer, Integer> map = new HashMap<>();
         if (str == null || str.isEmpty()) return map;
@@ -490,7 +513,6 @@ public class GameService {
         return map;
     }
 
-    // 발동 횟수 직렬화 {6: 2, 3: 1} → "6:2,3:1"
     private String serializeTriggerCount(Map<Integer, Integer> map) {
         return map.entrySet().stream()
                 .map(e -> e.getKey() + ":" + e.getValue())


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #26

## 📝 작업 내용
> AI 모델(RandomForest) 학습을 위한 몬테카를로 시뮬레이션 데이터 생성을 위해
> Java `GameService.calculateRounds()` 핵심 로직을 Python으로 재구현했습니다.
> Java vs Python 결과 비교 검증 기능 및 `/game/validate` 검증 엔드포인트도 추가했습니다.

## 📁 추가된 파일 / 수정된 파일

| 파일 | 변경 내용 |
|------|-----------|
| `backend/python_simulation/data_loader.py` | CSV 주가 데이터 로드 및 전처리 (pandas, 캐시 적용) |
| `backend/python_simulation/game_logic.py` | `calculateRounds()` Python 포팅 — priority 정렬, 카드 타입별 처리, 현금 부족 스킵, 파산 방지, roundAsset/returnRate 계산 |
| `backend/python_simulation/validator.py` | Python/Java 검증 모드 + 결과 비교 스크립트 |
| `backend/python_simulation/monte_carlo.py` | 몬테카를로 시뮬레이션 실행 및 결과 CSV 저장 |
| `backend/python_simulation/requirements.txt` | pandas, numpy |
| `backend/src/.../controller/GameController.java` | `POST /game/validate` 엔드포인트 추가 |
| `backend/src/.../service/GameService.java` | `validateGame()` 메서드 추가 (DB 저장 없이 start_date 직접 지정) |

## 🔍 주요 로직

### priority 기반 카드 발동 순서
```python
# priority 오름차순 정렬 → 역발상 투자(8번) priority=1 항상 먼저 발동
active_cards = sorted([CARDS[cid] for cid in applied_card_ids], key=lambda c: c['priority'])
```

### 현금 부족 스킵
```python
# 총자산의 5% 미만이면 매수 스킵
if cash < total_asset * 0.05: continue
```

### 파산 방지
```python
# 총자산이 initialAsset의 1% 이하면 카드 발동 중지
if total_asset > initial_asset * 0.01: ...
```

### BUY_EVERY_N
```python
# 매 5라운드마다 발동
triggered = (round_number % 5 == 0)
```

### 몬테카를로 시뮬레이션 흐름
```
1. 랜덤 시작 날짜 선택 (2007-09-01 ~ 2009-06-01)
2. 각 카드 선택 라운드(1, 25, 50, 75)마다 3개 중 1개 랜덤 선택
3. 게임 로직 실행 → 최종 수익률 계산
4. training_data.csv에 결과 저장
```

### POST /game/validate (검증 엔드포인트)
```json
// 요청
{
  "startDate": "2008-09-02",
  "cardSelections": {"1": 1, "25": 2, "50": 3, "75": 4}
}
// 응답: 라운드별 결과 JSON (Python 결과와 비교용)
```

## ✅ 테스트 결과

| 테스트 | 시작 날짜 | 카드 선택 | Python 수익률 | Java 수익률 |
|--------|-----------|-----------|--------------|------------|
| test1 | 2008-09-02 | 1, 2, 3, 4 | -6.14% | -6.14% |
| test2 | 2008-09-02 | 8, 1, 2, 3 | +3.59% | +3.59% |
| test3 | 2008-09-02 | 11, 11, 11, 11 | -13.76% | -13.76% |
| test4 | 2008-09-02 | 9, 9, 9, 9 | -11.07% | -11.07% ✅ 완전 일치 |
| test5 | 2008-10-15 | 1, 7, 5, 10 | -14.36% | -14.36% |

> test1~3, test5는 부동소수점 반올림 오차로 최대 8원 차이 발생 (머신러닝 학습 데이터에 영향 없는 수준)

## 🔗 연관된 이슈
close #26