### PR TITLE
[Feature] 몬테카를로 시뮬레이션 10만 건 확장 및 multiprocessing 병렬화

### DIFF
--- a/backend/python_simulation/monte_carlo.py
+++ b/backend/python_simulation/monte_carlo.py
@@ -1,12 +1,15 @@
 """
 몬테카를로 시뮬레이션 — V1.5 학습 데이터 생성
 카드 선택 시점 인코딩: Card{i}_Round{r} 44차원
+10만 건 확장 + multiprocessing 병렬화
 """
 import os
 import random
 import csv
 import time
+import tempfile
 import numpy as np
+import multiprocessing as mp
 from datetime import datetime, timedelta
 from game_logic import run_game, CARDS
 from data_loader import get_price_list
@@ -19,12 +22,20 @@ ALL_CARD_IDS       = list(CARDS.keys())
 CARD_SELECT_ROUNDS = [1, 25, 50, 75]
 SIM_START          = datetime(2007, 9, 1)
 SIM_END            = datetime(2009, 6, 1)
+N_SIMULATIONS      = 100_000   # 기본 시뮬레이션 횟수
 
 # V1.5 컬럼: Card{i}_Round{r} 44개
 CARD_ROUND_COLS = [
     f'Card{i}_Round{r}'
     for i in range(1, 12)
     for r in CARD_SELECT_ROUNDS
+]
+
+FIELDNAMES = [
+    'sim_id', 'scenario_id', 'start_date',
+    'SPX_Return', 'SPX_Volatility',
+    *CARD_ROUND_COLS,
+    'Final_Return'
 ]
 
 
@@ -59,21 +70,26 @@ def make_card_round_encoding(card_selections: dict) -> dict:
     return encoding
 
 
-def run_simulation(n: int = 1000):
-    start_time = time.time()
-    fieldnames = [
-        'sim_id', 'scenario_id', 'start_date',
-        'SPX_Return', 'SPX_Volatility',
-        *CARD_ROUND_COLS,
-        'Final_Return'
-    ]
+def run_chunk(args):
+    """
+    병렬 워커 함수 — 시뮬레이션 청크 단위 실행 후 임시 CSV 경로 반환
+    args: (chunk_id, sim_id_start, chunk_size)
+    """
+    chunk_id, sim_id_start, chunk_size = args
+    random.seed(chunk_id)  # 청크별 시드 고정으로 재현성 확보
 
-    with open(OUTPUT_PATH, 'w', newline='', encoding='utf-8') as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames)
+    tmp_path = os.path.join(
+        tempfile.gettempdir(),
+        f'mc_chunk_{chunk_id}.csv'
+    )
+
+    with open(tmp_path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
         writer.writeheader()
 
         completed = 0
-        for sim_id in range(1, n + 1):
+        for i in range(chunk_size):
+            sim_id = sim_id_start + i
             start_date = random_start_date()
 
             spx_return, spx_vol = calc_spx_stats(start_date)
@@ -97,7 +113,6 @@ def run_simulation(n: int = 1000):
             except Exception:
                 continue
 
-            # V1.5 인코딩
             card_round_enc = make_card_round_encoding(card_selections)
 
             row = {
@@ -112,20 +127,68 @@ def run_simulation(n: int = 1000):
             writer.writerow(row)
             completed += 1
 
-            if sim_id % 100 == 0:
-                elapsed = time.time() - start_time
-                est_total = elapsed / sim_id * n
-                print(f'  {sim_id}/{n} 완료 ({elapsed:.0f}초 경과, 예상 총 {est_total:.0f}초)')
+    return tmp_path, completed
+
+
+def merge_chunks(tmp_paths: list, output_path: str) -> int:
+    """임시 CSV 파일들을 하나로 병합"""
+    total = 0
+    with open(output_path, 'w', newline='', encoding='utf-8') as out_f:
+        writer = csv.DictWriter(out_f, fieldnames=FIELDNAMES)
+        writer.writeheader()
+
+        for tmp_path in tmp_paths:
+            if not os.path.exists(tmp_path):
+                continue
+            with open(tmp_path, 'r', encoding='utf-8') as in_f:
+                reader = csv.DictReader(in_f)
+                for row in reader:
+                    writer.writerow(row)
+                    total += 1
+            os.remove(tmp_path)  # 임시 파일 삭제
+
+    return total
+
+
+def run_simulation(n: int = N_SIMULATIONS):
+    n_cores = mp.cpu_count()
+    chunk_size = n // n_cores
+    remainder  = n % n_cores
+
+    # 청크 분배: (chunk_id, sim_id_start, chunk_size)
+    chunks = []
+    sim_id_cursor = 1
+    for i in range(n_cores):
+        size = chunk_size + (1 if i < remainder else 0)
+        chunks.append((i, sim_id_cursor, size))
+        sim_id_cursor += size
+
+    print(f'시뮬레이션 시작: {n:,}건 / {n_cores}코어 병렬')
+    print(f'코어당 약 {chunk_size:,}건\n')
+
+    start_time = time.time()
+
+    with mp.Pool(processes=n_cores) as pool:
+        results = []
+        for idx, (tmp_path, completed) in enumerate(pool.imap_unordered(run_chunk, chunks)):
+            results.append(tmp_path)
+            elapsed = time.time() - start_time
+            print(f'  청크 {idx + 1}/{n_cores} 완료 — {completed:,}건 ({elapsed:.0f}초 경과)')
+
+    print('\nCSV 병합 중...')
+    total = merge_chunks(results, OUTPUT_PATH)
 
     elapsed = time.time() - start_time
-    print(f'\n시뮬레이션 완료: {OUTPUT_PATH}')
-    print(f'총 시간: {elapsed:.1f}초  /  1회 평균: {elapsed/max(completed,1)*1000:.1f}ms')
-    print(f'저장 건수: {completed}건')
+    print(f'\n✅ 시뮬레이션 완료: {OUTPUT_PATH}')
+    print(f'총 시간: {elapsed:.1f}초')
+    print(f'저장 건수: {total:,}건')
+    print(f'1회 평균: {elapsed / max(total, 1) * 1000:.1f}ms')
 
 
 if __name__ == '__main__':
     try:
-        n = int(input('시뮬레이션 횟수 입력 (예: 1000): ') or 1000)
+        n_input = input(f'시뮬레이션 횟수 입력 (기본값 {N_SIMULATIONS:,}): ').strip()
+        n = int(n_input) if n_input else N_SIMULATIONS
     except ValueError:
-        n = 1000
+        n = N_SIMULATIONS
     run_simulation(n)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #34

## 📝 작업 내용
> 기존 단일 루프 1만 건 시뮬레이션을 10만 건으로 확장하고,
> `multiprocessing.Pool`을 활용한 병렬화로 실행 시간을 단축했습니다.
> V1.5 순열(7,920개) 기준 조합당 평균 매칭 수가 1.26건 → 12.6건으로 증가하여
> 평가 1, 3의 통계적 유의성이 개선되었습니다.

## 📁 수정된 파일

| 파일 | 변경 내용 |
|------|-----------|
| `backend/python_simulation/monte_carlo.py` | 10만 건 확장 + multiprocessing 병렬화 + CSV 병합 로직 추가 |

## 🔍 주요 로직

### 병렬화 구조
```python
# CPU 코어 수(8코어)만큼 청크 분배 후 병렬 실행
with mp.Pool(processes=n_cores) as pool:
    for idx, (tmp_path, completed) in enumerate(pool.imap_unordered(run_chunk, chunks)):
        ...

# 각 청크 결과를 임시 CSV로 저장 후 하나로 병합
merge_chunks(results, OUTPUT_PATH)
```

### 재현성 확보
```python
random.seed(chunk_id)  # 청크별 시드 고정
```

## ✅ 테스트 결과

### 실행 성능
| 항목 | 결과 |
|------|------|
| 총 시뮬레이션 | 100,000건 |
| 사용 코어 | 8코어 |
| 총 소요 시간 | 522.7초 (약 8분 43초) |
| 1회 평균 | 5.2ms |

### 모델 성능 (10만 건 재학습)
| 모델 | R² | MAE |
|------|-----|-----|
| 평균 예측 (베이스라인1) | -0.0000 | 8.4737% |
| LinearRegression | 0.3764 | 6.6980% |
| **RandomForest V1.5** | **0.8492** | **3.0443%** |

### 1만 건 vs 10만 건 평가 비교
| 항목 | 1만 건 | 10만 건 |
|------|--------|---------|
| 평가1 TOP5 실제 평균 | 데이터 부족 (1건) | +9.10% (2~3건) |
| 평가2 AI 우수성 | +9.49%p | **+20.70%p** |
| 평가3 일치도 | 0/5 | 0/5 |

## 🔗 연관된 이슈
close #34