### PR TITLE
[Feature] V2 모델 학습 및 실시간 추천 로직 구현 (recommend_v2.py)

### DIFF
--- a/backend/python_simulation/recommend_v2.py
+++ b/backend/python_simulation/recommend_v2.py
@@ -1,0 +1,256 @@
+"""
+V2 - 실시간 카드 추천 모델
+라운드별 스냅샷 데이터(40만 row) 학습
+
+구조:
+  입력 25차원:
+    SPX_Return_so_far, SPX_Volatility_so_far, SPX_MDD_so_far (3)
+    current_round (1)
+    Already_Card1~11 (multi-hot, 11)
+    Selected_Card_1~11 (one-hot, 11)
+  출력: Final_Return (회귀)
+
+기능:
+  - 모델 학습 + 정량 평가 (R², MAE, RMSE)
+  - 베이스라인 비교 (평균 예측, LinearRegression)
+  - V1.5 모델과 성능 비교
+  - 실시간 추천 CLI
+"""
+import os
+import pickle
+import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings('ignore')
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.linear_model import LinearRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+
+DATA_DIR    = os.path.join(os.path.dirname(__file__), '..', 'data', 'simulation')
+DATA_PATH   = os.path.join(DATA_DIR, 'training_data_v2.csv')
+MODEL_PATH  = os.path.join(DATA_DIR, 'model_v2.pkl')
+
+ALL_CARD_IDS       = list(range(1, 12))
+CARD_SELECT_ROUNDS = [1, 25, 50, 75]
+
+CARD_NAMES = {
+    1: '거인의 어깨',   2: '황금 적립',     3: '공포탐욕',
+    4: '금 피난처',     5: '기술의 파도',   6: '낙폭과대 사냥',
+    7: '원유 베팅',     8: '역발상 투자',   9: '애플 줍줍',
+    10: '채권 피난처',  11: '분할매수 장인',
+}
+
+ALREADY_COLS  = [f'Already_Card{i}' for i in range(1, 12)]
+SELECTED_COLS = [f'Selected_Card_{i}' for i in range(1, 12)]
+
+FEATURE_COLS = [
+    'SPX_Return_so_far',
+    'SPX_Volatility_so_far',
+    'SPX_MDD_so_far',
+    'current_round',
+    *ALREADY_COLS,
+    *SELECTED_COLS,
+]  # 총 25차원
+
+
+# =============================================
+# 1. 모델 학습 + 평가
+# =============================================
+def train_and_evaluate(df: pd.DataFrame):
+    """V2 RandomForest 학습 + 베이스라인 비교"""
+    X = df[FEATURE_COLS].values
+    y = df['Final_Return'].values
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
+
+    print(f'\n===== V2 모델 학습 =====')
+    print(f'학습: {len(X_train):,}건  /  테스트: {len(X_test):,}건')
+    print(f'입력 차원: {X.shape[1]}차원')
+
+    # 베이스라인 1: 평균 예측
+    mean_pred = np.full_like(y_test, y_train.mean())
+    r2_mean   = r2_score(y_test, mean_pred)
+    mae_mean  = mean_absolute_error(y_test, mean_pred)
+    print(f'\n[베이스라인 - 평균 예측]')
+    print(f'  R²: {r2_mean:.4f}  MAE: {mae_mean:.4f}%')
+
+    # 베이스라인 2: LinearRegression
+    lr = LinearRegression()
+    lr.fit(X_train, y_train)
+    lr_pred = lr.predict(X_test)
+    r2_lr   = r2_score(y_test, lr_pred)
+    mae_lr  = mean_absolute_error(y_test, lr_pred)
+    print(f'\n[베이스라인 - LinearRegression]')
+    print(f'  R²: {r2_lr:.4f}  MAE: {mae_lr:.4f}%')
+
+    # RandomForest V2
+    rf = RandomForestRegressor(
+        n_estimators=100, max_depth=10, random_state=42, n_jobs=-1
+    )
+    rf.fit(X_train, y_train)
+    rf_pred = rf.predict(X_test)
+    r2_rf   = r2_score(y_test, rf_pred)
+    mae_rf  = mean_absolute_error(y_test, rf_pred)
+    rmse_rf = np.sqrt(mean_squared_error(y_test, rf_pred))
+    print(f'\n[RandomForest V2]')
+    print(f'  R²: {r2_rf:.4f}  MAE: {mae_rf:.4f}%  RMSE: {rmse_rf:.4f}%')
+
+    # 비교 요약
+    print(f'\n===== 모델 비교 요약 =====')
+    print(f'{"모델":<25} {"R²":>8} {"MAE":>10}')
+    print('-' * 45)
+    print(f'{"평균 예측 (베이스라인1)":<25} {r2_mean:>8.4f} {mae_mean:>9.4f}%')
+    print(f'{"LinearRegression":<25} {r2_lr:>8.4f} {mae_lr:>9.4f}%')
+    print(f'{"RandomForest V2":<25} {r2_rf:>8.4f} {mae_rf:>9.4f}%')
+
+    print(f'\n===== V1.5 vs V2 성능 비교 =====')
+    print(f'{"항목":<20} {"V1.5":>10} {"V2":>10}')
+    print('-' * 42)
+    print(f'{"학습 데이터":<20} {"10만 row":>10} {"40만 row":>10}')
+    print(f'{"입력 차원":<20} {"47차원":>10} {"25차원":>10}')
+    print(f'{"R²":<20} {"0.8787":>10} {r2_rf:>10.4f}')
+    print(f'{"MAE":<20} {"2.7899%":>10} {mae_rf:>9.4f}%')
+
+    # 모델 저장
+    with open(MODEL_PATH, 'wb') as f:
+        pickle.dump(rf, f)
+    print(f'\n모델 저장: {MODEL_PATH}')
+
+    return rf
+
+
+# =============================================
+# 2. 실시간 추천 함수
+# =============================================
+def make_feature(spx_return: float, spx_vol: float, spx_mdd: float,
+                 current_round: int, already_cards: list,
+                 selected_card: int) -> list:
+    """25차원 입력 벡터 생성"""
+    already_enc  = {f'Already_Card{i}': 0 for i in range(1, 12)}
+    selected_enc = {f'Selected_Card_{i}': 0 for i in range(1, 12)}
+
+    for card_id in already_cards:
+        already_enc[f'Already_Card{card_id}'] = 1
+
+    selected_enc[f'Selected_Card_{selected_card}'] = 1
+
+    return [
+        spx_return, spx_vol, spx_mdd, current_round,
+        *[already_enc[c] for c in ALREADY_COLS],
+        *[selected_enc[c] for c in SELECTED_COLS],
+    ]
+
+
+def recommend_card(model, spx_return: float, spx_vol: float, spx_mdd: float,
+                   current_round: int, already_cards: list) -> list:
+    """
+    현재 상태에서 선택 가능한 카드들을 예측 후 순위 반환
+    already_cards: 이미 선택한 카드 ID 리스트
+    """
+    candidates = [c for c in ALL_CARD_IDS if c not in already_cards]
+
+    features = [
+        make_feature(spx_return, spx_vol, spx_mdd,
+                     current_round, already_cards, c)
+        for c in candidates
+    ]
+
+    predictions = model.predict(features)
+    results = sorted(
+        zip(candidates, predictions),
+        key=lambda x: -x[1]
+    )
+    return results  # [(card_id, predicted_return), ...]
+
+
+# =============================================
+# 3. CLI
+# =============================================
+def run_cli(model):
+    """실시간 추천 CLI"""
+    print('\n' + '=' * 60)
+    print(' 📊 V2 실시간 카드 추천 시스템')
+    print('=' * 60)
+
+    while True:
+        print('\n' + '-' * 60)
+        try:
+            spx_return = float(input(' SPX 수익률 so_far (%) → '))
+            spx_vol    = float(input(' SPX 변동성 so_far    → '))
+            spx_mdd    = float(input(' SPX MDD so_far (%)   → '))
+            current_round = int(input(' 현재 라운드 (1/25/50/75) → '))
+        except ValueError:
+            print(' ⚠️  숫자를 입력해주세요.')
+            continue
+
+        if current_round not in CARD_SELECT_ROUNDS:
+            print(f' ⚠️  라운드는 1, 25, 50, 75 중 하나여야 합니다.')
+            continue
+
+        # 이미 선택한 카드 입력
+        already_cards = []
+        round_idx = CARD_SELECT_ROUNDS.index(current_round)
+        if round_idx > 0:
+            print(f' 이미 선택한 카드 {round_idx}개를 입력하세요.')
+            for i in range(round_idx):
+                print(f'   카드 목록: ' +
+                      ', '.join([f'{k}:{v}' for k, v in CARD_NAMES.items()]))
+                try:
+                    card_id = int(input(f'   {i+1}번째 카드 ID → '))
+                    if card_id in ALL_CARD_IDS:
+                        already_cards.append(card_id)
+                    else:
+                        print(f'   ⚠️  1~11 사이 ID를 입력하세요.')
+                except ValueError:
+                    pass
+
+        # 추천 실행
+        results = recommend_card(
+            model, spx_return, spx_vol, spx_mdd,
+            current_round, already_cards
+        )
+
+        print(f'\n {"순위":<4} {"카드":>14} {"예측 수익률":>12}')
+        print(' ' + '-' * 34)
+        for rank, (card_id, pred) in enumerate(results[:5], 1):
+            print(f' {rank}위   {CARD_NAMES[card_id]:>14}   {pred:>+.2f}%')
+
+        again = input('\n 다시 추천받으시겠습니까? (y/n) → ').strip().lower()
+        if again != 'y':
+            print(' 👋 종료합니다.')
+            break
+
+
+# =============================================
+# 메인
+# =============================================
+def main():
+    if not os.path.exists(DATA_PATH):
+        print(f'❌ 학습 데이터 없음: {DATA_PATH}')
+        print('먼저 monte_carlo_v2.py를 실행하세요.')
+        return
+
+    df = pd.read_csv(DATA_PATH)
+    print(f'데이터 로드: {len(df):,}건  /  컬럼: {len(df.columns)}개')
+    print(f'게임 수: {df["sim_id"].nunique():,}개')
+
+    # 학습 or 로드
+    if os.path.exists(MODEL_PATH):
+        ans = input('\n저장된 모델이 있습니다. 재학습할까요? (y/n): ').strip().lower()
+        if ans == 'y':
+            model = train_and_evaluate(df)
+        else:
+            with open(MODEL_PATH, 'rb') as f:
+                model = pickle.load(f)
+            print('저장된 모델 로드 완료')
+    else:
+        model = train_and_evaluate(df)
+
+    run_cli(model)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #46

## 📝 작업 내용
> V2 실시간 추천 모델 학습을 위해 recommend_v2.py를 구현하였습니다.
> 40만 row V2 데이터를 학습하여 RandomForest 모델을 구축하고
> 실시간 추천 CLI를 작성하였습니다.

## 📁 수정된 파일

| 파일 | 변경 내용 |
|------|-----------|
| `backend/python_simulation/recommend_v2.py` | 신규 — V2 모델 학습 + 실시간 추천 로직 |

## 🔍 주요 로직

### 25차원 입력 구성
```python
FEATURE_COLS = [
    'SPX_Return_so_far', 'SPX_Volatility_so_far', 'SPX_MDD_so_far',
    'current_round',
    *ALREADY_COLS,   # Already_Card1~11 (multi-hot, 11차원)
    *SELECTED_COLS,  # Selected_Card_1~11 (one-hot, 11차원)
]  # 총 25차원 + 1 = 26차원 (current_round 포함)
```

### 실시간 추천 함수
```python
# 남은 카드 후보별 예측 후 최고 수익률 카드 추천
candidates = [c for c in ALL_CARD_IDS if c not in already_cards]
predictions = model.predict(features)
results = sorted(zip(candidates, predictions), key=lambda x: -x[1])
```

## ✅ 테스트 결과

### 모델 성능
| 모델 | R² | MAE |
|------|-----|-----|
| 평균 예측 (베이스라인1) | -0.0000 | 8.4314% |
| LinearRegression | 0.1280 | 7.9068% |
| **RandomForest V2** | **0.4552** | **5.9066%** |

### V1.5 vs V2 성능 비교
| 항목 | V1.5 | V2 |
|------|------|----|
| 학습 데이터 | 10만 row | 40만 row |
| 입력 차원 | 47차원 | 25차원 |
| R² | 0.8787 | 0.4552 |
| MAE | 2.7899% | 5.9066% |

## ⚠️ 문제점 및 한계

### 문제점 1 - 라운드 1에서 so_far 지표 전부 0
`calc_spx_so_far(closes, up_to_idx=1)`에서 데이터가 1개라 수익률, 변동성, MDD 계산 불가.
라운드 1 데이터 10만 건 전부 so_far 지표가 0이라 모델이 라운드 1 상황을 학습 못함.

### 문제점 2 - R²가 V1.5 대비 크게 낮음 (0.88 → 0.45)
라운드 1에서 시장 정보가 없는 상태로 Final_Return을 예측해야 하므로
불확실성이 높아 R²가 낮게 나옴.

### 문제점 3 - 카드 추천이 모든 후보 동일
Feature Importance 분석 결과:
| 구분 | 중요도 합계 |
|------|------------|
| 시장 지표 3개 | 69.1% |
| Already_Card | 26.1% |
| current_round | 2.7% |
| **Selected_Card 전체** | **~2%** |

`Selected_Card`가 11차원으로 분산되어 카드당 중요도 0.2% 이하.
모델이 카드 차이를 구분 못해 모든 카드에 동일한 수익률 예측.

### 문제점 4 - V2 설계 구조적 한계
`Final_Return`을 타겟으로 사용하면 카드 1개 선택 차이가
최종 수익률에 미치는 영향(~2%)이 시장 상황(69%)에 비해 너무 작음.

## 🔧 개선 방향
타겟을 `Final_Return` → `Card_Contribution`(카드 선택의 상대적 기여도)으로 변경.
같은 시작 날짜 + 같은 이전 카드 조합에서 11개 카드를 전부 시도하여
평균 대비 각 카드의 수익률 기여도를 직접 학습하는 방향으로 재설계 예정.
→ `Selected_Card`의 Feature Importance가 ~2% → 50%+ 로 향상 기대.

## 🔗 연관된 이슈
close #46