### PR TITLE
[Feature] V2 시뮬레이션 재설계 (Card_Contribution 타겟)

### DIFF
--- a/backend/python_simulation/monte_carlo_v2.py
+++ b/backend/python_simulation/monte_carlo_v2.py
@@ -1,17 +1,26 @@
 """
-몬테카를로 시뮬레이션 V2 — 라운드별 스냅샷 데이터 생성
+몬테카를로 시뮬레이션 V2 재설계 — Card_Contribution 타겟
 실시간 추천 모델(V2) 학습용
 
-V1.5와 차이:
-  V1.5: 게임당 1 row (4개 카드 완성 상태) → 사후 평가용
-  V2:   게임당 4 row (라운드별 스냅샷)    → 실시간 추천용
+기존 V2 문제:
+  타겟이 Final_Return이라 Selected_Card Feature Importance ~2%
+  → 카드 추천이 전부 동일하게 나오는 구조적 문제
 
-V2 입력 25차원:
-  시장 정보 3개: SPX_Return_so_far, SPX_Volatility_so_far, SPX_MDD_so_far
-  진행 상황 1개: current_round (1, 25, 50, 75)
-  이미 선택한 카드 11개: Already_Card1~11 (multi-hot)
-  이번 선택 카드 11개: Selected_Card_1~11 (one-hot)
-  출력: Final_Return (회귀)
+재설계 핵심:
+  타겟을 Card_Contribution으로 변경
+  Card_Contribution = 해당 카드 Final_Return - 11개 카드 평균 Final_Return
+  → 시장 효과 상쇄, 카드 효과만 순수하게 학습
+
+데이터 구조:
+  게임 1개 → 라운드 4개 × 카드 최대 11개 = 최대 44 row
+  10만 게임 → 약 350만 row (중복 제외)
+
+입력 26차원:
+  시장 정보 3: SPX_Return_so_far, SPX_Volatility_so_far, SPX_MDD_so_far
+  진행 상황 1: current_round
+  이미 선택한 카드 11: Already_Card1~11 (multi-hot)
+  이번 선택 카드 11: Selected_Card_1~11 (one-hot)
+출력: Card_Contribution (회귀)
 """
 import os
 import random
@@ -28,15 +37,14 @@ OUTPUT_DIR  = os.path.join(os.path.dirname(__file__), '..', 'data', 'simulation'
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 OUTPUT_PATH = os.path.join(OUTPUT_DIR, 'training_data_v2.csv')
 
-ALL_CARD_IDS       = list(CARDS.keys())          # [1, 2, ..., 11]
+ALL_CARD_IDS       = list(CARDS.keys())   # [1, 2, ..., 11]
 CARD_SELECT_ROUNDS = [1, 25, 50, 75]
 SIM_START          = datetime(2007, 9, 1)
 SIM_END            = datetime(2009, 6, 1)
-N_SIMULATIONS      = 100_000   # 게임 수 (row는 4배인 40만)ㄴㄴㄴ
+N_SIMULATIONS      = 100_000
 
-# 컬럼 정의
-ALREADY_COLS  = [f'Already_Card{i}' for i in range(1, 12)]   # 11개
-SELECTED_COLS = [f'Selected_Card_{i}' for i in range(1, 12)] # 11개
+ALREADY_COLS  = [f'Already_Card{i}' for i in range(1, 12)]
+SELECTED_COLS = [f'Selected_Card_{i}' for i in range(1, 12)]
 
 FIELDNAMES = [
     'sim_id', 'scenario_id', 'start_date',
@@ -44,29 +52,23 @@ FIELDNAMES = [
     'SPX_Return_so_far', 'SPX_Volatility_so_far', 'SPX_MDD_so_far',
     *ALREADY_COLS,
     *SELECTED_COLS,
-    'Final_Return',
+    'Card_Contribution',
 ]
 
 
-# ── 날짜 헬퍼 ────────────────────────────────────────────
 def random_start_date() -> str:
     delta = (SIM_END - SIM_START).days
     rand_day = SIM_START + timedelta(days=random.randint(0, delta))
     return rand_day.strftime('%Y-%m-%d')
 
 
-# ── 시장 지표 계산 ────────────────────────────────────────
 def calc_spx_so_far(closes: np.ndarray, up_to_idx: int):
-    """
-    closes: 전체 100라운드 종가 배열
-    up_to_idx: 현재 라운드까지의 인덱스 (exclusive)
-    returns: (return_so_far, volatility_so_far, mdd_so_far)
-    """
+    """현재 라운드까지의 시장 지표 계산"""
     sub = closes[:up_to_idx]
     if len(sub) < 2:
         return 0.0, 0.0, 0.0
 
-    ret = (sub[-1] - sub[0]) / sub[0] * 100
+    ret   = (sub[-1] - sub[0]) / sub[0] * 100
     daily = np.diff(sub) / sub[:-1] * 100
     vol   = float(np.std(daily)) if len(daily) > 0 else 0.0
 
@@ -78,31 +80,31 @@ def calc_spx_so_far(closes: np.ndarray, up_to_idx: int):
     return round(float(ret), 4), round(vol, 4), round(mdd, 4)
 
 
-# ── 인코딩 헬퍼 ──────────────────────────────────────────
 def make_already_encoding(selected_so_far: list) -> dict:
-    """이미 선택한 카드 multi-hot 인코딩"""
     enc = {col: 0 for col in ALREADY_COLS}
     for card_id in selected_so_far:
-        col = f'Already_Card{card_id}'
-        if col in enc:
-            enc[col] = 1
+        key = f'Already_Card{card_id}'
+        if key in enc:
+            enc[key] = 1
     return enc
 
 
 def make_selected_encoding(card_id: int) -> dict:
-    """이번 라운드 선택 카드 one-hot 인코딩"""
     enc = {col: 0 for col in SELECTED_COLS}
-    col = f'Selected_Card_{card_id}'
-    if col in enc:
-        enc[col] = 1
+    key = f'Selected_Card_{card_id}'
+    if key in enc:
+        enc[key] = 1
     return enc
 
 
-# ── 청크 워커 ────────────────────────────────────────────
 def run_chunk(args):
     """
-    병렬 워커 — 게임 청크 단위 실행 후 임시 CSV 경로 반환
-    args: (chunk_id, sim_id_start, chunk_size)
+    병렬 워커 — 게임 청크 단위 실행
+    각 게임마다:
+      1. 시작 날짜 고정
+      2. 나머지 카드 조합 랜덤 고정
+      3. 각 라운드에서 가능한 카드 전부 시도
+      4. Card_Contribution = 해당 카드 수익률 - 가능한 카드들의 평균 수익률
     """
     chunk_id, sim_id_start, chunk_size = args
     random.seed(chunk_id)
@@ -127,29 +129,16 @@ def run_chunk(args):
                 continue
             closes = spx.iloc[:100]['Close'].values
 
-            # 카드 선택 (각 라운드마다 3개 뽑고 1개 선택, 중복 없이)
-            selected_ids    = []
-            card_selections = {}
-            for r in CARD_SELECT_ROUNDS:
-                pool    = [c for c in ALL_CARD_IDS if c not in selected_ids]
-                if len(pool) < 3:
-                    pool = ALL_CARD_IDS.copy()
-                options = random.sample(pool, min(3, len(pool)))
-                chosen  = random.choice(options)
-                card_selections[r] = chosen
-                selected_ids.append(chosen)
+            # 기준 카드 조합 설정 (나머지 3장 랜덤 고정)
+            base_selections = {}
+            pool = ALL_CARD_IDS.copy()
+            random.shuffle(pool)
+            for idx, r in enumerate(CARD_SELECT_ROUNDS):
+                base_selections[r] = pool[idx]
 
-            # 게임 실행 → Final_Return
-            try:
-                result = run_game(start_date, card_selections)
-            except Exception:
-                continue
-
-            final_return = result['final_return_rate']
-
-            # 라운드별 스냅샷 4 row 생성
-            round_to_idx   = {1: 1, 25: 25, 50: 50, 75: 75}
-            already_so_far = []  # 이전 라운드들에서 선택한 카드 누적
+            # 라운드별로 카드 전부 시도
+            round_to_idx   = {1: 2, 25: 25, 50: 50, 75: 75}
+            already_so_far = []
 
             for r in CARD_SELECT_ROUNDS:
                 up_to_idx = round_to_idx[r]
@@ -157,33 +146,68 @@ def run_chunk(args):
                     closes, up_to_idx
                 )
 
-                selected_card = card_selections[r]
-                already_enc   = make_already_encoding(already_so_far)
-                selected_enc  = make_selected_encoding(selected_card)
-
-                row = {
-                    'sim_id':                sim_id,
-                    'scenario_id':           'lehman',
-                    'start_date':            start_date,
-                    'current_round':         r,
-                    'SPX_Return_so_far':     ret_so_far,
-                    'SPX_Volatility_so_far': vol_so_far,
-                    'SPX_MDD_so_far':        mdd_so_far,
-                    **already_enc,
-                    **selected_enc,
-                    'Final_Return':          final_return,
+                # 나머지 라운드 카드 고정
+                other_rounds_cards = {
+                    other_r: base_selections[other_r]
+                    for other_r in CARD_SELECT_ROUNDS
+                    if other_r != r
                 }
-                writer.writerow(row)
 
-                # 다음 라운드를 위해 이번 선택 카드 누적
-                already_so_far.append(selected_card)
+                # 이번 라운드에서 시도 가능한 카드
+                # (이미 선택한 카드 + 나머지 라운드 고정 카드 제외)
+                excluded = set(already_so_far) | set(other_rounds_cards.values())
+                candidates = [c for c in ALL_CARD_IDS if c not in excluded]
+
+                if len(candidates) < 2:
+                    already_so_far.append(base_selections[r])
+                    continue
+
+                # 각 후보 카드로 게임 실행
+                final_returns = {}
+                for candidate_card in candidates:
+                    card_selections = dict(other_rounds_cards)
+                    card_selections[r] = candidate_card
+
+                    try:
+                        result = run_game(start_date, card_selections)
+                        final_returns[candidate_card] = result['final_return_rate']
+                    except Exception:
+                        continue
+
+                if len(final_returns) < 2:
+                    already_so_far.append(base_selections[r])
+                    continue
+
+                # Card_Contribution 계산
+                avg_return  = np.mean(list(final_returns.values()))
+                already_enc = make_already_encoding(already_so_far)
+
+                for candidate_card, final_return in final_returns.items():
+                    contribution = round(final_return - avg_return, 4)
+                    selected_enc = make_selected_encoding(candidate_card)
+
+                    row = {
+                        'sim_id':                sim_id,
+                        'scenario_id':           'lehman',
+                        'start_date':            start_date,
+                        'current_round':         r,
+                        'SPX_Return_so_far':     ret_so_far,
+                        'SPX_Volatility_so_far': vol_so_far,
+                        'SPX_MDD_so_far':        mdd_so_far,
+                        **already_enc,
+                        **selected_enc,
+                        'Card_Contribution':     contribution,
+                    }
+                    writer.writerow(row)
+
+                # 다음 라운드를 위해 base 카드 누적
+                already_so_far.append(base_selections[r])
 
             completed += 1
 
     return tmp_path, completed
 
 
-# ── CSV 병합 ─────────────────────────────────────────────
 def merge_chunks(tmp_paths: list, output_path: str) -> int:
     total = 0
     with open(output_path, 'w', newline='', encoding='utf-8') as out_f:
@@ -201,7 +225,6 @@ def merge_chunks(tmp_paths: list, output_path: str) -> int:
     return total
 
 
-# ── 메인 ─────────────────────────────────────────────────
 def run_simulation(n: int = N_SIMULATIONS):
     n_cores    = mp.cpu_count()
     chunk_size = n // n_cores
@@ -214,8 +237,8 @@ def run_simulation(n: int = N_SIMULATIONS):
         chunks.append((i, sim_id_cursor, size))
         sim_id_cursor += size
 
-    print(f'V2 시뮬레이션 시작: {n:,}게임 / {n_cores}코어 병렬')
-    print(f'예상 총 row 수: {n * 4:,}개 (게임당 4 row)')
+    print(f'V2 재설계 시뮬레이션 시작: {n:,}게임 / {n_cores}코어 병렬')
+    print(f'게임당 최대 44 row (4라운드 × 11카드, 중복 제외)')
     print(f'코어당 약 {chunk_size:,}게임\n')
 
     start_time = time.time()
@@ -228,17 +251,18 @@ def run_simulation(n: int = N_SIMULATIONS):
             results.append(tmp_path)
             elapsed = time.time() - start_time
             print(f'  청크 {idx + 1}/{n_cores} 완료 — {completed:,}게임 '
-                  f'({completed * 4:,} row) ({elapsed:.0f}초 경과)')
+                  f'({elapsed:.0f}초 경과)')
 
     print('\nCSV 병합 중...')
     total = merge_chunks(results, OUTPUT_PATH)
 
     elapsed = time.time() - start_time
-    print(f'\n✅ V2 시뮬레이션 완료: {OUTPUT_PATH}')
+    print(f'\n✅ V2 재설계 시뮬레이션 완료: {OUTPUT_PATH}')
     print(f'총 시간: {elapsed:.1f}초')
     print(f'저장 row 수: {total:,}개')
-    print(f'게임 수: {total // 4:,}개')
-    print(f'1게임 평균: {elapsed / max(total // 4, 1) * 1000:.1f}ms')
+    print(f'게임 수: {n:,}개')
+    print(f'게임당 평균 row: {total / max(n, 1):.1f}개')
+    print(f'1게임 평균: {elapsed / max(n, 1) * 1000:.1f}ms')
 
 
 if __name__ == '__main__':

--- a/backend/python_simulation/recommend_v2.py
+++ b/backend/python_simulation/recommend_v2.py
@@ -1,20 +1,9 @@
 """
-V2 - 실시간 카드 추천 모델
-라운드별 스냅샷 데이터(40만 row) 학습
+V2 재설계 - Card_Contribution 타겟 모델
+실시간 카드 추천 시스템
 
-구조:
-  입력 25차원:
-    SPX_Return_so_far, SPX_Volatility_so_far, SPX_MDD_so_far (3)
-    current_round (1)
-    Already_Card1~11 (multi-hot, 11)
-    Selected_Card_1~11 (one-hot, 11)
-  출력: Final_Return (회귀)
-
-기능:
-  - 모델 학습 + 정량 평가 (R², MAE, RMSE)
-  - 베이스라인 비교 (평균 예측, LinearRegression)
-  - V1.5 모델과 성능 비교
-  - 실시간 추천 CLI
+타겟: Card_Contribution (평균 대비 카드 기여도)
+입력: 26차원 (시장 3 + current_round 1 + Already 11 + Selected 11)
 """
 import os
 import pickle
@@ -27,9 +16,9 @@ from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
-DATA_DIR    = os.path.join(os.path.dirname(__file__), '..', 'data', 'simulation')
-DATA_PATH   = os.path.join(DATA_DIR, 'training_data_v2.csv')
-MODEL_PATH  = os.path.join(DATA_DIR, 'model_v2.pkl')
+DATA_DIR   = os.path.join(os.path.dirname(__file__), '..', 'data', 'simulation')
+DATA_PATH  = os.path.join(DATA_DIR, 'training_data_v2.csv')
+MODEL_PATH = os.path.join(DATA_DIR, 'model_v2.pkl')
 
 ALL_CARD_IDS       = list(range(1, 12))
 CARD_SELECT_ROUNDS = [1, 25, 50, 75]
@@ -51,24 +40,24 @@ FEATURE_COLS = [
     'current_round',
     *ALREADY_COLS,
     *SELECTED_COLS,
-]  # 총 25차원
+]  # 총 26차원
 
 
 # =============================================
 # 1. 모델 학습 + 평가
 # =============================================
 def train_and_evaluate(df: pd.DataFrame):
-    """V2 RandomForest 학습 + 베이스라인 비교"""
     X = df[FEATURE_COLS].values
-    y = df['Final_Return'].values
+    y = df['Card_Contribution'].values
 
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, random_state=42
     )
 
-    print(f'\n===== V2 모델 학습 =====')
+    print(f'\n===== V2 재설계 모델 학습 =====')
     print(f'학습: {len(X_train):,}건  /  테스트: {len(X_test):,}건')
     print(f'입력 차원: {X.shape[1]}차원')
+    print(f'타겟: Card_Contribution (평균 대비 카드 기여도)')
 
     # 베이스라인 1: 평균 예측
     mean_pred = np.full_like(y_test, y_train.mean())
@@ -95,7 +84,7 @@ def train_and_evaluate(df: pd.DataFrame):
     r2_rf   = r2_score(y_test, rf_pred)
     mae_rf  = mean_absolute_error(y_test, rf_pred)
     rmse_rf = np.sqrt(mean_squared_error(y_test, rf_pred))
-    print(f'\n[RandomForest V2]')
+    print(f'\n[RandomForest V2 재설계]')
     print(f'  R²: {r2_rf:.4f}  MAE: {mae_rf:.4f}%  RMSE: {rmse_rf:.4f}%')
 
     # 비교 요약
@@ -104,15 +93,24 @@ def train_and_evaluate(df: pd.DataFrame):
     print('-' * 45)
     print(f'{"평균 예측 (베이스라인1)":<25} {r2_mean:>8.4f} {mae_mean:>9.4f}%')
     print(f'{"LinearRegression":<25} {r2_lr:>8.4f} {mae_lr:>9.4f}%')
-    print(f'{"RandomForest V2":<25} {r2_rf:>8.4f} {mae_rf:>9.4f}%')
+    print(f'{"RandomForest V2 재설계":<25} {r2_rf:>8.4f} {mae_rf:>9.4f}%')
 
-    print(f'\n===== V1.5 vs V2 성능 비교 =====')
-    print(f'{"항목":<20} {"V1.5":>10} {"V2":>10}')
-    print('-' * 42)
-    print(f'{"학습 데이터":<20} {"10만 row":>10} {"40만 row":>10}')
-    print(f'{"입력 차원":<20} {"47차원":>10} {"25차원":>10}')
-    print(f'{"R²":<20} {"0.8787":>10} {r2_rf:>10.4f}')
-    print(f'{"MAE":<20} {"2.7899%":>10} {mae_rf:>9.4f}%')
+    # Feature Importance 출력
+    print(f'\n===== Feature Importance (상위 15개) =====')
+    imp = pd.Series(rf.feature_importances_, index=FEATURE_COLS)
+    imp_sorted = imp.sort_values(ascending=False)
+    for feat, val in imp_sorted.head(15).items():
+        bar = '█' * int(val * 200)
+        print(f'  {feat:<30} {val:.4f}  {bar}')
+
+    # Selected_Card 합계
+    selected_imp = imp[[c for c in FEATURE_COLS if 'Selected' in c]].sum()
+    already_imp  = imp[[c for c in FEATURE_COLS if 'Already' in c]].sum()
+    market_imp   = imp[['SPX_Return_so_far', 'SPX_Volatility_so_far', 'SPX_MDD_so_far']].sum()
+    print(f'\n  시장 지표 합계:       {market_imp:.4f} ({market_imp*100:.1f}%)')
+    print(f'  Already_Card 합계:    {already_imp:.4f} ({already_imp*100:.1f}%)')
+    print(f'  Selected_Card 합계:   {selected_imp:.4f} ({selected_imp*100:.1f}%)')
+    print(f'  current_round:        {imp["current_round"]:.4f} ({imp["current_round"]*100:.1f}%)')
 
     # 모델 저장
     with open(MODEL_PATH, 'wb') as f:
@@ -128,13 +126,11 @@ def train_and_evaluate(df: pd.DataFrame):
 def make_feature(spx_return: float, spx_vol: float, spx_mdd: float,
                  current_round: int, already_cards: list,
                  selected_card: int) -> list:
-    """25차원 입력 벡터 생성"""
     already_enc  = {f'Already_Card{i}': 0 for i in range(1, 12)}
     selected_enc = {f'Selected_Card_{i}': 0 for i in range(1, 12)}
 
     for card_id in already_cards:
         already_enc[f'Already_Card{card_id}'] = 1
-
     selected_enc[f'Selected_Card_{selected_card}'] = 1
 
     return [
@@ -146,10 +142,6 @@ def make_feature(spx_return: float, spx_vol: float, spx_mdd: float,
 
 def recommend_card(model, spx_return: float, spx_vol: float, spx_mdd: float,
                    current_round: int, already_cards: list) -> list:
-    """
-    현재 상태에서 선택 가능한 카드들을 예측 후 순위 반환
-    already_cards: 이미 선택한 카드 ID 리스트
-    """
     candidates = [c for c in ALL_CARD_IDS if c not in already_cards]
 
     features = [
@@ -163,47 +155,44 @@ def recommend_card(model, spx_return: float, spx_vol: float, spx_mdd: float,
         zip(candidates, predictions),
         key=lambda x: -x[1]
     )
-    return results  # [(card_id, predicted_return), ...]
+    return results
 
 
 # =============================================
 # 3. CLI
 # =============================================
 def run_cli(model):
-    """실시간 추천 CLI"""
     print('\n' + '=' * 60)
-    print(' 📊 V2 실시간 카드 추천 시스템')
+    print(' 📊 V2 실시간 카드 추천 시스템 (재설계)')
+    print(' 추천 기준: 평균 대비 카드 기여도 (Card_Contribution)')
     print('=' * 60)
 
     while True:
         print('\n' + '-' * 60)
         try:
-            spx_return = float(input(' SPX 수익률 so_far (%) → '))
-            spx_vol    = float(input(' SPX 변동성 so_far    → '))
-            spx_mdd    = float(input(' SPX MDD so_far (%)   → '))
+            spx_return    = float(input(' SPX 수익률 so_far (%) → '))
+            spx_vol       = float(input(' SPX 변동성 so_far    → '))
+            spx_mdd       = float(input(' SPX MDD so_far (%)   → '))
             current_round = int(input(' 현재 라운드 (1/25/50/75) → '))
         except ValueError:
             print(' ⚠️  숫자를 입력해주세요.')
             continue
 
         if current_round not in CARD_SELECT_ROUNDS:
-            print(f' ⚠️  라운드는 1, 25, 50, 75 중 하나여야 합니다.')
+            print(' ⚠️  라운드는 1, 25, 50, 75 중 하나여야 합니다.')
             continue
 
         # 이미 선택한 카드 입력
         already_cards = []
         round_idx = CARD_SELECT_ROUNDS.index(current_round)
         if round_idx > 0:
-            print(f' 이미 선택한 카드 {round_idx}개를 입력하세요.')
+            print(f'\n 이미 선택한 카드 {round_idx}개를 입력하세요.')
+            print(' ' + ', '.join([f'{k}:{v}' for k, v in CARD_NAMES.items()]))
             for i in range(round_idx):
-                print(f'   카드 목록: ' +
-                      ', '.join([f'{k}:{v}' for k, v in CARD_NAMES.items()]))
                 try:
                     card_id = int(input(f'   {i+1}번째 카드 ID → '))
                     if card_id in ALL_CARD_IDS:
                         already_cards.append(card_id)
-                    else:
-                        print(f'   ⚠️  1~11 사이 ID를 입력하세요.')
                 except ValueError:
                     pass
 
@@ -213,10 +202,11 @@ def run_cli(model):
             current_round, already_cards
         )
 
-        print(f'\n {"순위":<4} {"카드":>14} {"예측 수익률":>12}')
-        print(' ' + '-' * 34)
-        for rank, (card_id, pred) in enumerate(results[:5], 1):
-            print(f' {rank}위   {CARD_NAMES[card_id]:>14}   {pred:>+.2f}%')
+        print(f'\n {"순위":<4} {"카드":>14} {"기여도 예측":>12}')
+        print(' ' + '-' * 36)
+        for rank, (card_id, pred) in enumerate(results, 1):
+            marker = ' ★' if rank == 1 else ''
+            print(f' {rank}위   {CARD_NAMES[card_id]:>14}   {pred:>+.2f}%{marker}')
 
         again = input('\n 다시 추천받으시겠습니까? (y/n) → ').strip().lower()
         if again != 'y':
@@ -236,8 +226,9 @@ def main():
     df = pd.read_csv(DATA_PATH)
     print(f'데이터 로드: {len(df):,}건  /  컬럼: {len(df.columns)}개')
     print(f'게임 수: {df["sim_id"].nunique():,}개')
+    print(f'Card_Contribution 평균: {df["Card_Contribution"].mean():.4f}%')
+    print(f'Card_Contribution 표준편차: {df["Card_Contribution"].std():.4f}%')
 
-    # 학습 or 로드
     if os.path.exists(MODEL_PATH):
         ans = input('\n저장된 모델이 있습니다. 재학습할까요? (y/n): ').strip().lower()
         if ans == 'y':


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #48

## 📝 작업 내용
> 기존 V2의 구조적 문제(Selected_Card Feature Importance ~2%)를 해결하기 위해
> 타겟을 Final_Return → Card_Contribution으로 변경하여 재설계하였습니다.
> 같은 조건에서 카드 11개를 전부 시도하여 평균 대비 기여도를 타겟으로 학습함으로써
> 카드 선택의 변별력을 확보하였습니다.

## 📁 수정된 파일

| 파일 | 변경 내용 |
|------|-----------|
| backend/python_simulation/monte_carlo_v2.py | 재설계 — Card_Contribution 타겟 방식으로 변경 |
| backend/python_simulation/recommend_v2.py | 재작성 — 타겟 Card_Contribution, Feature Importance 출력 추가 |

## 🔍 주요 로직

Card_Contribution 계산:
  같은 시작 날짜, 나머지 3장 고정
  카드 1~11 각각 시도 → Final_Return 수집
  avg_return = mean(모든 카드 Final_Return)
  Card_Contribution = 해당 카드 Final_Return - avg_return

중복 방지:
  excluded = set(already_so_far) | set(other_rounds_cards.values())
  candidates = [c for c in ALL_CARD_IDS if c not in excluded]

## ✅ 테스트 결과

모델 성능:
| 모델 | R² | MAE |
|------|-----|-----|
| 평균 예측 (베이스라인1) | -0.0000 | 2.2648% |
| LinearRegression | 0.0340 | 2.3589% |
| RandomForest V2 재설계 | 0.3187 | 1.9056% |

Feature Importance 비교 (핵심 개선):
| 구분 | 기존 V2 | 재설계 V2 |
|------|---------|----------|
| 시장 지표 3개 | 69.1% | 74.6% |
| Already_Card | 26.1% | 3.0% |
| Selected_Card | ~2% | 16.6% |
| current_round | 2.7% | 5.8% |

추천 결과 검증 (라운드 25, 금 피난처 선택 후, SPX -15%):
| 순위 | 카드 | 기여도 예측 |
|------|------|------------|
| 1위 | 기술의 파도 | +2.26% |
| 2위 | 분할매수 장인 | +2.21% |
| 3위 | 공포탐욕 | +0.26% |
| 9위 | 황금 적립 | -3.61% |
| 10위 | 채권 피난처 | -5.18% |

금 피난처 선택 후 채권/황금 등 금 자산 중복은 하위 추천 → 합리적 추천 확인

## ⚠️ 한계

- R² 0.32로 낮은 수준 (Card_Contribution 표준편차 4.13%로 예측 난이도 높음)
- 1만 게임(32만 row) 기준 학습 → 10만 게임으로 확장 시 성능 향상 기대
- 시뮬레이션 시간: 게임당 160ms → 10만 게임 기준 약 33분 소요

## 🔗 연관된 이슈
close #48