### PR TITLE
[Feature] recommend_v2.py RF/XGBoost 모델 각각 저장

### DIFF
--- a/backend/python_simulation/recommend_v2.py
+++ b/backend/python_simulation/recommend_v2.py
@@ -19,7 +19,9 @@ from xgboost import XGBRegressor
 
 DATA_DIR   = os.path.join(os.path.dirname(__file__), '..', 'data', 'simulation')
 DATA_PATH  = os.path.join(DATA_DIR, 'training_data_v2.csv')
-MODEL_PATH = os.path.join(DATA_DIR, 'model_v2.pkl')
+MODEL_PATH     = os.path.join(DATA_DIR, 'model_v2.pkl')
+MODEL_RF_PATH  = os.path.join(DATA_DIR, 'model_v2_rf.pkl')
+MODEL_XGB_PATH = os.path.join(DATA_DIR, 'model_v2_xgb.pkl')
 
 ALL_CARD_IDS       = list(range(1, 12))
 CARD_SELECT_ROUNDS = [1, 25, 50, 75]
@@ -120,18 +122,12 @@ def train_and_evaluate(df: pd.DataFrame):
     if r2_xgb > r2_rf:
         best_model = xgb
         best_name  = 'XGBoost'
-        best_r2    = r2_xgb
-        imp_series = pd.Series(
-            xgb.feature_importances_, index=FEATURE_COLS
-        )
+        imp_series = pd.Series(xgb.feature_importances_, index=FEATURE_COLS)
         print(f'\n✅ 최적 모델: XGBoost (R² {r2_xgb:.4f} > RF {r2_rf:.4f})')
     else:
         best_model = rf
         best_name  = 'RandomForest'
-        best_r2    = r2_rf
-        imp_series = pd.Series(
-            rf.feature_importances_, index=FEATURE_COLS
-        )
+        imp_series = pd.Series(rf.feature_importances_, index=FEATURE_COLS)
         print(f'\n✅ 최적 모델: RandomForest (R² {r2_rf:.4f} >= XGB {r2_xgb:.4f})')
 
     # Feature Importance 출력
@@ -149,10 +145,18 @@ def train_and_evaluate(df: pd.DataFrame):
     print(f'  Selected_Card 합계:   {selected_imp:.4f} ({selected_imp*100:.1f}%)')
     print(f'  current_round:        {imp_series["current_round"]:.4f} ({imp_series["current_round"]*100:.1f}%)')
 
-    # 최적 모델 저장
+    # 모델 저장 (RF, XGB 각각 + 최적 모델)
+    with open(MODEL_RF_PATH, 'wb') as f:
+        pickle.dump(rf, f)
+    print(f'\nRF 모델 저장: {MODEL_RF_PATH}')
+
+    with open(MODEL_XGB_PATH, 'wb') as f:
+        pickle.dump(xgb, f)
+    print(f'XGB 모델 저장: {MODEL_XGB_PATH}')
+
     with open(MODEL_PATH, 'wb') as f:
         pickle.dump(best_model, f)
-    print(f'\n모델 저장: {MODEL_PATH} ({best_name})')
+    print(f'최적 모델 저장: {MODEL_PATH} ({best_name})')
 
     return best_model
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #52

## 📝 작업 내용
> evaluate_v2.py에서 RF vs XGBoost 스피어만 상관계수 비교 분석을 위해
> RandomForest와 XGBoost 모델을 각각 별도 파일로 저장하는 로직을 추가하였습니다.

## 📁 수정된 파일

| 파일 | 변경 내용 |
|------|-----------|
| backend/python_simulation/recommend_v2.py | RF/XGB 모델 각각 저장 로직 추가 |

## 🔍 주요 변경사항

기존:
  model_v2.pkl (최적 모델만 저장)

변경:
  model_v2_rf.pkl  (RandomForest 따로 저장)
  model_v2_xgb.pkl (XGBoost 따로 저장)
  model_v2.pkl     (최적 모델 유지 = XGBoost)

## ✅ 테스트 결과

세 파일 정상 생성 확인:
  model_v2_rf.pkl  ✅
  model_v2_xgb.pkl ✅
  model_v2.pkl     ✅ (XGBoost)

## 🔗 연관된 이슈
close #52