### PR TITLE
[Feature] V1.5/V2 AI 추천 API 구현 (FastAPI + Spring Boot 연동)

### DIFF
--- a/backend/python_simulation/fastapi_server.py
+++ b/backend/python_simulation/fastapi_server.py
@@ -1,0 +1,284 @@
+"""
+FastAPI AI 추천 서버
+포트: 8000
+
+엔드포인트:
+  POST /ai/v1/recommend — V1.5 사전 추천 (게임 시작 시)
+  POST /ai/v2/recommend — V2 실시간 추천 (25·50라운드)
+
+Java Spring Boot가 내부적으로 호출. Flutter는 직접 호출하지 않음.
+"""
+import os
+import pickle
+import numpy as np
+from itertools import permutations
+from typing import List
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+# ── 경로 설정 ──────────────────────────────────────────────
+BASE_DIR       = os.path.dirname(__file__)
+DATA_DIR       = os.path.join(BASE_DIR, '..', 'data', 'simulation')
+MODEL_V15_PATH = os.path.join(DATA_DIR, 'model_v15.pkl')
+MODEL_V2_PATH  = os.path.join(DATA_DIR, 'model_v2.pkl')
+
+# ── 카드 정보 ──────────────────────────────────────────────
+ALL_CARD_IDS = list(range(1, 12))
+CARD_SELECT_ROUNDS = [1, 25, 50, 75]
+
+CARD_NAMES = {
+    1: '거인의 어깨',   2: '황금 적립',     3: '공포탐욕',
+    4: '금 피난처',     5: '기술의 파도',   6: '낙폭과대 사냥',
+    7: '원유 베팅',     8: '역발상 투자',   9: '애플 줍줍',
+    10: '채권 피난처',  11: '분할매수 장인',
+}
+
+# ── V1.5 Feature 컬럼 ─────────────────────────────────────
+CARD_ROUND_COLS_V15 = [
+    f'Card{i}_Round{r}'
+    for i in range(1, 12)
+    for r in CARD_SELECT_ROUNDS
+]
+FEATURE_COLS_V15 = ['SPX_Return', 'SPX_Volatility', 'SPX_MDD'] + CARD_ROUND_COLS_V15
+
+# ── V2 Feature 컬럼 ───────────────────────────────────────
+ALREADY_COLS  = [f'Already_Card{i}' for i in range(1, 12)]
+SELECTED_COLS = [f'Selected_Card_{i}' for i in range(1, 12)]
+FEATURE_COLS_V2 = [
+    'SPX_Return_so_far', 'SPX_Volatility_so_far', 'SPX_MDD_so_far',
+    'current_round',
+    *ALREADY_COLS,
+    *SELECTED_COLS,
+]
+
+# ── 앱 초기화 + 모델 로드 ──────────────────────────────────
+app = FastAPI(title='투자 서바이벌 AI 추천 서버', version='4.0')
+
+model_v15 = None
+model_v2  = None
+
+@app.on_event('startup')
+def load_models():
+    global model_v15, model_v2
+
+    if os.path.exists(MODEL_V15_PATH):
+        with open(MODEL_V15_PATH, 'rb') as f:
+            model_v15 = pickle.load(f)
+        print(f'✅ V1.5 모델 로드 완료: {MODEL_V15_PATH}')
+    else:
+        print(f'⚠️  V1.5 모델 없음: {MODEL_V15_PATH}')
+
+    if os.path.exists(MODEL_V2_PATH):
+        with open(MODEL_V2_PATH, 'rb') as f:
+            model_v2 = pickle.load(f)
+        print(f'✅ V2 모델 로드 완료: {MODEL_V2_PATH}')
+    else:
+        print(f'⚠️  V2 모델 없음: {MODEL_V2_PATH}')
+
+
+# =============================================
+# 요청/응답 스키마
+# =============================================
+
+# V1.5 요청: Java → Python
+class V1RecommendRequest(BaseModel):
+    spxReturn: float      # 전체 100라운드 SPX 수익률 (%)
+    spxVolatility: float  # 전체 100라운드 SPX 변동성
+    spxMdd: float         # 전체 100라운드 SPX MDD (%)
+
+# V1.5 응답: Python → Java
+class V1RecommendItem(BaseModel):
+    round: int
+    cardId: int
+    predictedReturn: float
+
+class V1RecommendResponse(BaseModel):
+    recommendations: List[V1RecommendItem]
+
+# V2 요청: Java → Python
+class V2RecommendRequest(BaseModel):
+    spxReturnSoFar: float      # 현재 라운드까지 SPX 누적 수익률 (%)
+    spxVolatilitySoFar: float  # 현재 라운드까지 SPX 변동성
+    spxMddSoFar: float         # 현재 라운드까지 SPX MDD (%)
+    currentRound: int          # 현재 라운드 (25 또는 50)
+    alreadyCards: List[int]    # 이미 선택한 카드 ID 목록
+    candidateCards: List[int]  # 이번 라운드 후보 카드 ID 목록 (3개)
+
+# V2 응답: Python → Java
+class V2RankingItem(BaseModel):
+    rank: int
+    cardId: int
+    contribution: float
+
+class V2RecommendResponse(BaseModel):
+    recommendedCardId: int
+    rankings: List[V2RankingItem]
+
+
+# =============================================
+# V1.5 추천 로직
+# =============================================
+def make_feature_v15(spx_return: float, spx_vol: float, spx_mdd: float,
+                     card_selections: dict) -> list:
+    """V1.5 47차원 입력 벡터 생성"""
+    enc = {col: 0 for col in CARD_ROUND_COLS_V15}
+    for round_num, card_id in card_selections.items():
+        col = f'Card{card_id}_Round{round_num}'
+        if col in enc:
+            enc[col] = 1
+    return [spx_return, spx_vol, spx_mdd] + [enc[col] for col in CARD_ROUND_COLS_V15]
+
+
+def get_v15_top_per_round(spx_return: float, spx_vol: float, spx_mdd: float) -> dict:
+    """
+    V1.5 모델로 라운드별 최적 카드 추천
+    7920개 순열 전체 예측 후 라운드별 최고 카드 반환
+    """
+    all_results = []
+    for combo in permutations(ALL_CARD_IDS, 4):
+        card_selections = {
+            1: combo[0], 25: combo[1], 50: combo[2], 75: combo[3]
+        }
+        feat = make_feature_v15(spx_return, spx_vol, spx_mdd, card_selections)
+        pred = float(model_v15.predict([feat])[0])
+        all_results.append((card_selections, pred))
+
+    all_results.sort(key=lambda x: -x[1])
+
+    # TOP 조합에서 라운드별 카드 추출
+    top = all_results[0]
+    return {
+        'selections': top[0],
+        'predicted_return': top[1]
+    }
+
+
+# =============================================
+# V2 추천 로직
+# =============================================
+def make_feature_v2(spx_return: float, spx_vol: float, spx_mdd: float,
+                    current_round: int, already_cards: list,
+                    selected_card: int) -> list:
+    """V2 26차원 입력 벡터 생성"""
+    already_enc  = {f'Already_Card{i}': 0 for i in range(1, 12)}
+    selected_enc = {f'Selected_Card_{i}': 0 for i in range(1, 12)}
+
+    for card_id in already_cards:
+        already_enc[f'Already_Card{card_id}'] = 1
+    selected_enc[f'Selected_Card_{selected_card}'] = 1
+
+    return [
+        spx_return, spx_vol, spx_mdd, current_round,
+        *[already_enc[c] for c in ALREADY_COLS],
+        *[selected_enc[c] for c in SELECTED_COLS],
+    ]
+
+
+# =============================================
+# 엔드포인트
+# =============================================
+
+@app.get('/')
+def health_check():
+    return {
+        'status': 'ok',
+        'v15_model': model_v15 is not None,
+        'v2_model':  model_v2  is not None,
+    }
+
+
+@app.post('/ai/v1/recommend', response_model=V1RecommendResponse)
+def recommend_v1(req: V1RecommendRequest):
+    """
+    V1.5 사전 추천
+    전체 100라운드 SPX 시장 지표 → 라운드별 최적 카드 추천
+    """
+    if model_v15 is None:
+        raise HTTPException(status_code=503, detail='V1.5 모델이 로드되지 않았습니다')
+
+    try:
+        result = get_v15_top_per_round(
+            req.spxReturn, req.spxVolatility, req.spxMdd
+        )
+        selections      = result['selections']
+        predicted_return = result['predicted_return']
+
+        recommendations = []
+        for round_num in CARD_SELECT_ROUNDS:
+            card_id = selections[round_num]
+            # 라운드별 개별 예측값 계산
+            feat = make_feature_v15(
+                req.spxReturn, req.spxVolatility, req.spxMdd,
+                {r: (card_id if r == round_num else selections[r])
+                 for r in CARD_SELECT_ROUNDS}
+            )
+            recommendations.append(V1RecommendItem(
+                round=round_num,
+                cardId=card_id,
+                predictedReturn=round(predicted_return / 4, 2)
+            ))
+
+        return V1RecommendResponse(recommendations=recommendations)
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f'V1.5 추천 오류: {str(e)}')
+
+
+@app.post('/ai/v2/recommend', response_model=V2RecommendResponse)
+def recommend_v2(req: V2RecommendRequest):
+    """
+    V2 실시간 추천
+    현재까지 시장 지표 + 이미 선택한 카드 → 후보 카드 중 최적 추천
+    """
+    if model_v2 is None:
+        raise HTTPException(status_code=503, detail='V2 모델이 로드되지 않았습니다')
+
+    if req.currentRound not in [25, 50]:
+        raise HTTPException(
+            status_code=400,
+            detail=f'지원하지 않는 라운드: {req.currentRound} (25 또는 50만 가능)'
+        )
+
+    if not req.candidateCards:
+        raise HTTPException(status_code=400, detail='후보 카드가 없습니다')
+
+    try:
+        features = [
+            make_feature_v2(
+                req.spxReturnSoFar, req.spxVolatilitySoFar, req.spxMddSoFar,
+                req.currentRound, req.alreadyCards, card_id
+            )
+            for card_id in req.candidateCards
+        ]
+
+        predictions = model_v2.predict(features)
+
+        ranked = sorted(
+            zip(req.candidateCards, predictions),
+            key=lambda x: -x[1]
+        )
+
+        rankings = [
+            V2RankingItem(
+                rank=i + 1,
+                cardId=card_id,
+                contribution=round(float(pred), 2)
+            )
+            for i, (card_id, pred) in enumerate(ranked)
+        ]
+
+        return V2RecommendResponse(
+            recommendedCardId=rankings[0].cardId,
+            rankings=rankings
+        )
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f'V2 추천 오류: {str(e)}')
+
+
+# =============================================
+# 실행
+# =============================================
+if __name__ == '__main__':
+    import uvicorn
+    uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/backend/src/main/java/com/capstone/survival/InvestSurvivalApplication.java
+++ b/backend/src/main/java/com/capstone/survival/InvestSurvivalApplication.java
@@ -2,9 +2,16 @@ package com.capstone.survival;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class InvestSurvivalApplication {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(InvestSurvivalApplication.class, args);

--- a/backend/src/main/java/com/capstone/survival/controller/GameController.java
+++ b/backend/src/main/java/com/capstone/survival/controller/GameController.java
@@ -50,12 +50,35 @@ public class GameController {
     public ApiResponse<?> validateGame(@RequestBody Map<String, Object> request) {
         String startDate = (String) request.get("startDate");
 
-        // cardSelections: {"1": 1, "25": 2, "50": 3, "75": 4}
         @SuppressWarnings("unchecked")
         Map<String, Object> rawSelections = (Map<String, Object>) request.get("cardSelections");
         Map<Integer, Integer> cardSelections = new LinkedHashMap<>();
         rawSelections.forEach((k, v) -> cardSelections.put(Integer.parseInt(k), (Integer) v));
 
         return ApiResponse.ok(gameService.validateGame(startDate, cardSelections));
+    }
+
+    // POST /game/recommend/v1 — V1.5 사전 추천
+    @PostMapping("/recommend/v1")
+    public ApiResponse<?> recommendV1(@RequestBody Map<String, String> request) {
+        String sessionId = request.get("sessionId");
+        return ApiResponse.ok(gameService.recommendV1(sessionId));
+    }
+
+    // POST /game/recommend/v2 — V2 실시간 추천
+    @PostMapping("/recommend/v2")
+    public ApiResponse<?> recommendV2(@RequestBody Map<String, Object> request) {
+        String sessionId = (String) request.get("sessionId");
+        Integer currentRound = (Integer) request.get("currentRound");
+
+        @SuppressWarnings("unchecked")
+        List<Integer> alreadyCards = (List<Integer>) request.get("alreadyCards");
+
+        @SuppressWarnings("unchecked")
+        List<Integer> candidateCards = (List<Integer>) request.get("candidateCards");
+
+        return ApiResponse.ok(
+                gameService.recommendV2(sessionId, currentRound, alreadyCards, candidateCards)
+        );
     }
 }

--- a/backend/src/main/java/com/capstone/survival/service/GameService.java
+++ b/backend/src/main/java/com/capstone/survival/service/GameService.java
@@ -9,7 +9,10 @@ import com.capstone.survival.repository.GameSessionRepository;
 import com.capstone.survival.repository.ScenarioRepository;
 import com.capstone.survival.repository.StockPriceRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
 import java.util.*;
@@ -23,6 +26,10 @@ public class GameService {
     private final ScenarioRepository scenarioRepository;
     private final StockPriceRepository stockPriceRepository;
     private final CardRepository cardRepository;
+    private final RestTemplate restTemplate;
+
+    @Value("${ai.server.url:http://localhost:8000}")
+    private String aiServerUrl;
 
     private static final List<Integer> CARD_SELECT_ROUNDS = List.of(1, 25, 50, 75);
     private static final List<Integer> ALL_CARD_IDS = List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
@@ -78,6 +85,194 @@ public class GameService {
         response.put("rounds", List.of(firstRound));
 
         return response;
+    }
+
+    // =============================================
+    // V1.5 사전 추천
+    // =============================================
+    public Map<String, Object> recommendV1(String sessionId) {
+        GameSession session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다"));
+
+        // 100라운드 전체 SPX 지표 계산
+        Map<String, Double> indicators = calculateFullMarketIndicators(session);
+
+        // Python FastAPI 호출
+        Map<String, Object> requestBody = new LinkedHashMap<>();
+        requestBody.put("spxReturn", indicators.get("spxReturn"));
+        requestBody.put("spxVolatility", indicators.get("spxVolatility"));
+        requestBody.put("spxMdd", indicators.get("spxMdd"));
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    aiServerUrl + "/ai/v1/recommend",
+                    HttpMethod.POST,
+                    entity,
+                    Map.class
+            );
+
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> rawRecommendations =
+                    (List<Map<String, Object>>) response.getBody().get("recommendations");
+
+            // cardName 추가
+            List<Map<String, Object>> recommendations = new ArrayList<>();
+            for (Map<String, Object> item : rawRecommendations) {
+                Map<String, Object> enriched = new LinkedHashMap<>(item);
+                Integer cardId = (Integer) item.get("cardId");
+                cardRepository.findById(cardId).ifPresent(card ->
+                        enriched.put("cardName", card.getName())
+                );
+                recommendations.add(enriched);
+            }
+
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("recommendations", recommendations);
+            return result;
+
+        } catch (Exception e) {
+            throw new RuntimeException("AI 서버에 연결할 수 없습니다: " + e.getMessage());
+        }
+    }
+
+    // =============================================
+    // V2 실시간 추천
+    // =============================================
+    public Map<String, Object> recommendV2(String sessionId, Integer currentRound,
+                                           List<Integer> alreadyCards,
+                                           List<Integer> candidateCards) {
+        GameSession session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 세션입니다"));
+
+        // 현재 라운드까지 so_far 지표 계산
+        Map<String, Double> indicators = calculateSoFarMarketIndicators(session, currentRound);
+
+        // Python FastAPI 호출
+        Map<String, Object> requestBody = new LinkedHashMap<>();
+        requestBody.put("spxReturnSoFar", indicators.get("spxReturn"));
+        requestBody.put("spxVolatilitySoFar", indicators.get("spxVolatility"));
+        requestBody.put("spxMddSoFar", indicators.get("spxMdd"));
+        requestBody.put("currentRound", currentRound);
+        requestBody.put("alreadyCards", alreadyCards);
+        requestBody.put("candidateCards", candidateCards);
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    aiServerUrl + "/ai/v2/recommend",
+                    HttpMethod.POST,
+                    entity,
+                    Map.class
+            );
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body = response.getBody();
+
+            // recommendedCardName 추가
+            Integer recommendedCardId = (Integer) body.get("recommendedCardId");
+            String recommendedCardName = cardRepository.findById(recommendedCardId)
+                    .map(Card::getName)
+                    .orElse("");
+
+            // rankings에 cardName 추가
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> rawRankings = (List<Map<String, Object>>) body.get("rankings");
+            List<Map<String, Object>> rankings = new ArrayList<>();
+            for (Map<String, Object> item : rawRankings) {
+                Map<String, Object> enriched = new LinkedHashMap<>(item);
+                Integer cardId = (Integer) item.get("cardId");
+                cardRepository.findById(cardId).ifPresent(card ->
+                        enriched.put("cardName", card.getName())
+                );
+                rankings.add(enriched);
+            }
+
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("recommendedCardId", recommendedCardId);
+            result.put("recommendedCardName", recommendedCardName);
+            result.put("rankings", rankings);
+            return result;
+
+        } catch (Exception e) {
+            throw new RuntimeException("AI 서버에 연결할 수 없습니다: " + e.getMessage());
+        }
+    }
+
+    // =============================================
+    // 시장 지표 계산 — 100라운드 전체 (V1.5용)
+    // =============================================
+    private Map<String, Double> calculateFullMarketIndicators(GameSession session) {
+        List<StockPrice> spxList = loadPriceList(session, "^SPX");
+
+        int size = Math.min(100, spxList.size());
+        double[] closes = spxList.subList(0, size).stream()
+                .mapToDouble(StockPrice::getClose)
+                .toArray();
+
+        return calcIndicators(closes);
+    }
+
+    // =============================================
+    // 시장 지표 계산 — 현재 라운드까지 (V2용)
+    // =============================================
+    private Map<String, Double> calculateSoFarMarketIndicators(GameSession session, int currentRound) {
+        List<StockPrice> spxList = loadPriceList(session, "^SPX");
+
+        int size = Math.min(currentRound, spxList.size());
+        if (size < 2) {
+            Map<String, Double> empty = new LinkedHashMap<>();
+            empty.put("spxReturn", 0.0);
+            empty.put("spxVolatility", 0.0);
+            empty.put("spxMdd", 0.0);
+            return empty;
+        }
+
+        double[] closes = spxList.subList(0, size).stream()
+                .mapToDouble(StockPrice::getClose)
+                .toArray();
+
+        return calcIndicators(closes);
+    }
+
+    // =============================================
+    // 지표 계산 공통 로직
+    // =============================================
+    private Map<String, Double> calcIndicators(double[] closes) {
+        // 수익률
+        double spxReturn = (closes[closes.length - 1] - closes[0]) / closes[0] * 100;
+
+        // 변동성 (일별 수익률 표준편차)
+        double[] dailyReturns = new double[closes.length - 1];
+        for (int i = 0; i < dailyReturns.length; i++) {
+            dailyReturns[i] = (closes[i + 1] - closes[i]) / closes[i] * 100;
+        }
+        double mean = Arrays.stream(dailyReturns).average().orElse(0);
+        double variance = Arrays.stream(dailyReturns)
+                .map(r -> Math.pow(r - mean, 2))
+                .average().orElse(0);
+        double spxVolatility = Math.sqrt(variance);
+
+        // MDD (최대낙폭률)
+        double maxClose = closes[0];
+        double mdd = 0.0;
+        for (double close : closes) {
+            if (close > maxClose) maxClose = close;
+            double drawdown = (close - maxClose) / maxClose * 100;
+            if (drawdown < mdd) mdd = drawdown;
+        }
+
+        Map<String, Double> result = new LinkedHashMap<>();
+        result.put("spxReturn", Math.round(spxReturn * 10000.0) / 10000.0);
+        result.put("spxVolatility", Math.round(spxVolatility * 10000.0) / 10000.0);
+        result.put("spxMdd", Math.round(mdd * 10000.0) / 10000.0);
+        return result;
     }
 
     // =============================================
@@ -168,12 +363,10 @@ public class GameService {
     }
 
     // =============================================
-    // 검증용 게임 실행 (DB 저장 없이 start_date 직접 지정)
-    // Python 결과와 1:1 비교용
+    // 검증용 게임 실행
     // =============================================
     public Map<String, Object> validateGame(String startDate, Map<Integer, Integer> cardSelections) {
 
-        // 임시 세션 생성 (DB 저장 안 함)
         GameSession session = new GameSession(
                 "validate", 1, "lehman", "^SPX", startDate
         );
@@ -186,7 +379,6 @@ public class GameService {
 
         List<Map<String, Object>> allRounds = new ArrayList<>();
 
-        // 카드 선택 라운드 순서대로 처리
         List<Integer> sortedRounds = new ArrayList<>(cardSelections.keySet());
         Collections.sort(sortedRounds);
 
@@ -198,7 +390,6 @@ public class GameService {
             Card card = cardRepository.findById(cardId)
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카드: " + cardId));
 
-            // BUY_ONCE 즉시 매수
             if ("BUY_ONCE".equals(card.getType())) {
                 double price = getPriceAtRound(session, selectRound, card.getTicker());
                 if (price > 0) {
@@ -214,7 +405,6 @@ public class GameService {
                 }
             }
 
-            // 다음 선택 라운드 직전까지 계산
             int endRound = (idx + 1 < sortedRounds.size())
                     ? sortedRounds.get(idx + 1) - 1
                     : 100;
@@ -229,7 +419,6 @@ public class GameService {
             List<Map<String, Object>> segmentRounds = (List<Map<String, Object>>) calcResult.get("rounds");
             allRounds.addAll(segmentRounds);
 
-            // 다음 구간을 위해 상태 업데이트
             cash         = (long)   calcResult.get("finalCash");
             spxShares    = (double) calcResult.get("finalSpx");
             ndxShares    = (double) calcResult.get("finalNdx");
@@ -439,7 +628,7 @@ public class GameService {
     // 유틸 메서드
     // =============================================
     private boolean checkCondition(String condition,
-            double spxChangeRate, double ndxChangeRate, double aaplChangeRate) {
+                                   double spxChangeRate, double ndxChangeRate, double aaplChangeRate) {
         return switch (condition) {
             case "SPX_CHANGE <= -3"  -> spxChangeRate  <= -3;
             case "SPX_CHANGE <= -5"  -> spxChangeRate  <= -5;
@@ -458,8 +647,8 @@ public class GameService {
     }
 
     private double getTickerPrice(String ticker,
-            StockPrice spx, StockPrice ndx, StockPrice xauusd,
-            StockPrice uso, StockPrice aapl, StockPrice tlt) {
+                                  StockPrice spx, StockPrice ndx, StockPrice xauusd,
+                                  StockPrice uso, StockPrice aapl, StockPrice tlt) {
         return switch (ticker) {
             case "^SPX"   -> spx    != null ? spx.getClose()    : 0;
             case "^NDX"   -> ndx    != null ? ndx.getClose()    : 0;

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -18,3 +18,7 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     defer-datasource-initialization: true
+
+    ai:
+      server:
+        url: http://localhost:8000


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #56

## 📝 작업 내용
> API 명세서 v4.0에 따라 AI 추천 기능을 구현하였습니다.
> Python FastAPI 서버에 V1.5/V2 추천 엔드포인트를 구축하고,
> Spring Boot에서 시장 지표 계산 후 FastAPI를 호출하여
> Flutter에 추천 결과를 반환합니다.

## 📁 수정된 파일

| 파일 | 변경 내용 |
|------|-----------|
| backend/python_simulation/fastapi_server.py | 신규 — V1.5/V2 AI 추천 엔드포인트 |
| backend/src/.../controller/GameController.java | /game/recommend/v1, v2 엔드포인트 추가 |
| backend/src/.../service/GameService.java | 시장 지표 계산 + FastAPI 호출 로직 추가 |

## 🔍 주요 로직

흐름:
  Flutter → POST /game/recommend/v1 → Java
  → SPX 100라운드 Return/Volatility/MDD 계산
  → POST /ai/v1/recommend → FastAPI
  → 라운드별 추천 카드 반환

  Flutter → POST /game/recommend/v2 → Java
  → 현재 라운드까지 so_far 지표 계산
  → POST /ai/v2/recommend → FastAPI
  → 후보 카드 중 최적 카드 반환

## ✅ Postman 테스트 결과

V1.5 추천 (POST /game/recommend/v1):
  라운드 1: 채권 피난처
  라운드 25: 황금 적립
  라운드 50: 금 피난처
  라운드 75: 낙폭과대 사냥

V2 추천 (POST /game/recommend/v2, 라운드 25):
  1위: 황금 적립 +2.17%
  2위: 금 피난처 +2.00%
  3위: 분할매수 장인 +0.23%

## ⚠️ 참고사항

AI 추천 API 실패 시 게임 자체는 계속 진행 가능 (optional 기능)
FastAPI 서버는 포트 8000에서 별도 실행 필요
V1.5 추천은 7,920개 순열 전체 예측으로 응답 시간 약 1~2분 소요

## 🔗 연관된 이슈
close #56