### PR TITLE
[Feature] Flutter AI 추천 UI + 차트/보유종목 개편 (명세서 v4반영)

### DIFF
--- a/frontEnd/lib/models/v1_recommend_result.dart
+++ b/frontEnd/lib/models/v1_recommend_result.dart
@@ -1,0 +1,46 @@
+class RoundRecommendation {
+  final int round;
+  final int cardId;
+  final String cardName;
+  final double predictedReturn;
+
+  RoundRecommendation({
+    required this.round,
+    required this.cardId,
+    required this.cardName,
+    required this.predictedReturn,
+  });
+
+  factory RoundRecommendation.fromJson(Map<String, dynamic> json) {
+    return RoundRecommendation(
+      round:           json['round'] as int,
+      cardId:          json['cardId'] as int,
+      cardName:        json['cardName'] as String,
+      predictedReturn: (json['predictedReturn'] as num).toDouble(),
+    );
+  }
+}
+
+class V1RecommendResult {
+  final List<RoundRecommendation> recommendations;
+
+  V1RecommendResult({required this.recommendations});
+
+  factory V1RecommendResult.fromJson(Map<String, dynamic> json) {
+    final list = json['recommendations'] as List<dynamic>;
+    return V1RecommendResult(
+      recommendations: list
+          .map((e) => RoundRecommendation.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  // 특정 라운드의 추천 카드 ID 반환
+  int? cardIdForRound(int round) {
+    try {
+      return recommendations.firstWhere((r) => r.round == round).cardId;
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/frontEnd/lib/models/v2_recommend_result.dart
+++ b/frontEnd/lib/models/v2_recommend_result.dart
@@ -1,0 +1,54 @@
+class CardRanking {
+  final int rank;
+  final int cardId;
+  final String cardName;
+  final double contribution;
+
+  CardRanking({
+    required this.rank,
+    required this.cardId,
+    required this.cardName,
+    required this.contribution,
+  });
+
+  factory CardRanking.fromJson(Map<String, dynamic> json) {
+    return CardRanking(
+      rank:         json['rank'] as int,
+      cardId:       json['cardId'] as int,
+      cardName:     json['cardName'] as String,
+      contribution: (json['contribution'] as num).toDouble(),
+    );
+  }
+}
+
+class V2RecommendResult {
+  final int recommendedCardId;
+  final String recommendedCardName;
+  final List<CardRanking> rankings;
+
+  V2RecommendResult({
+    required this.recommendedCardId,
+    required this.recommendedCardName,
+    required this.rankings,
+  });
+
+  factory V2RecommendResult.fromJson(Map<String, dynamic> json) {
+    final list = json['rankings'] as List<dynamic>;
+    return V2RecommendResult(
+      recommendedCardId:   json['recommendedCardId'] as int,
+      recommendedCardName: json['recommendedCardName'] as String,
+      rankings: list
+          .map((e) => CardRanking.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  // 특정 카드의 기여도 반환
+  double? contributionFor(int cardId) {
+    try {
+      return rankings.firstWhere((r) => r.cardId == cardId).contribution;
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/frontEnd/lib/screens/game_result_screen.dart
+++ b/frontEnd/lib/screens/game_result_screen.dart
@@ -1,31 +1,78 @@
 import 'package:flutter/material.dart';
 import '../models/game_session.dart';
 
-class GameResultScreen extends StatelessWidget {
+class GameResultScreen extends StatefulWidget {
   final GameSession session;
 
   const GameResultScreen({super.key, required this.session});
 
+  @override
+  State<GameResultScreen> createState() => _GameResultScreenState();
+}
+
+class _GameResultScreenState extends State<GameResultScreen>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _assetAnim;
+  late Animation<double> _returnAnim;
+
   double get _finalAsset {
-    // 마지막 라운드의 roundAsset, 없으면 initialAsset
-    for (int i = session.rounds.length - 1; i >= 0; i--) {
-      if (session.rounds[i].roundAsset != null) {
-        return session.rounds[i].roundAsset!;
+    for (int i = widget.session.rounds.length - 1; i >= 0; i--) {
+      if (widget.session.rounds[i].roundAsset != null) {
+        return widget.session.rounds[i].roundAsset!;
       }
     }
-    return session.initialAsset;
+    return widget.session.initialAsset.toDouble();
   }
 
   double get _finalReturnRate {
-    for (int i = session.rounds.length - 1; i >= 0; i--) {
-      if (session.rounds[i].returnRate != null) {
-        return session.rounds[i].returnRate!;
+    for (int i = widget.session.rounds.length - 1; i >= 0; i--) {
+      if (widget.session.rounds[i].returnRate != null) {
+        return widget.session.rounds[i].returnRate!;
       }
     }
     return 0.0;
   }
 
-  bool get _isProfit => _finalReturnRate >= 0;
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 2000),
+    );
+
+    // 자산 카운트업: initialAsset → finalAsset
+    _assetAnim = Tween<double>(
+      begin: widget.session.initialAsset.toDouble(),
+      end: _finalAsset,
+    ).animate(CurvedAnimation(
+      parent: _controller,
+      curve: const Interval(0.0, 0.8, curve: Curves.easeOut),
+    ));
+
+    // 수익률 카운트업: 0 → finalReturnRate
+    _returnAnim = Tween<double>(
+      begin: 0,
+      end: _finalReturnRate,
+    ).animate(CurvedAnimation(
+      parent: _controller,
+      curve: const Interval(0.0, 0.8, curve: Curves.easeOut),
+    ));
+
+
+    // 화면 진입 후 0.3초 딜레이 후 시작
+    Future.delayed(const Duration(milliseconds: 300), () {
+      if (mounted) _controller.forward();
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   String _formatNumber(double value) {
     return value
@@ -38,9 +85,11 @@ class GameResultScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final profit = _isProfit;
+    final profit     = _finalReturnRate >= 0;
     final returnRate = _finalReturnRate;
-    final color = profit ? const Color(0xFFE03131) : const Color(0xFF1971C2);
+    final color      = profit
+        ? const Color(0xFFE03131)
+        : const Color(0xFF1971C2);
 
     return Scaffold(
       backgroundColor: const Color(0xFFFAF9F5),
@@ -50,35 +99,35 @@ class GameResultScreen extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // 타이틀
+              // 태그
               Container(
-                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 10, vertical: 4),
                 decoration: BoxDecoration(
                   color: const Color(0xFFEEEDFE),
                   borderRadius: BorderRadius.circular(20),
                 ),
-                child: const Text(
-                  '게임 종료',
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                    color: Color(0xFF3C3489),
-                  ),
-                ),
+                child: const Text('게임 종료',
+                    style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: Color(0xFF3C3489))),
               ),
               const SizedBox(height: 12),
+
+              // 시나리오 제목
               Text(
-                session.scenarioTitle,
+                widget.session.scenarioTitle,
                 style: const TextStyle(
-                  fontSize: 22,
-                  fontWeight: FontWeight.w800,
-                  color: Color(0xFF111111),
-                ),
+                    fontSize: 22,
+                    fontWeight: FontWeight.w800,
+                    color: Color(0xFF111111)),
               ),
               const SizedBox(height: 4),
               Text(
-                '${session.totalRounds}라운드 완료',
-                style: const TextStyle(fontSize: 14, color: Color(0xFF6B7684)),
+                '${widget.session.totalRounds}라운드 완료',
+                style: const TextStyle(
+                    fontSize: 14, color: Color(0xFF6B7684)),
               ),
 
               const Spacer(),
@@ -90,7 +139,8 @@ class GameResultScreen extends StatelessWidget {
                 decoration: BoxDecoration(
                   color: Colors.white,
                   borderRadius: BorderRadius.circular(20),
-                  border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
+                  border: Border.all(
+                      color: const Color(0xFFEEEEEE), width: 1),
                 ),
                 child: Column(
                   children: [
@@ -98,17 +148,16 @@ class GameResultScreen extends StatelessWidget {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          '시작 자산',
-                          style: TextStyle(fontSize: 14, color: Color(0xFF6B7684)),
-                        ),
+                        const Text('시작 자산',
+                            style: TextStyle(
+                                fontSize: 14,
+                                color: Color(0xFF6B7684))),
                         Text(
-                          '₩${_formatNumber(session.initialAsset)}',
+                          '₩${_formatNumber(widget.session.initialAsset.toDouble())}',
                           style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
-                            color: Color(0xFF111111),
-                          ),
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
+                              color: Color(0xFF111111)),
                         ),
                       ],
                     ),
@@ -119,45 +168,44 @@ class GameResultScreen extends StatelessWidget {
                       child: Row(
                         children: [
                           Expanded(
-                            child: Container(
-                              height: 1,
-                              color: const Color(0xFFEEEEEE),
-                            ),
-                          ),
+                              child: Container(
+                                  height: 1,
+                                  color: const Color(0xFFEEEEEE))),
                           Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 12),
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12),
                             child: Icon(
                               profit
-                                  ? Icons.arrow_downward_rounded
+                                  ? Icons.arrow_upward_rounded
                                   : Icons.arrow_downward_rounded,
                               color: color,
                               size: 28,
                             ),
                           ),
                           Expanded(
-                            child: Container(
-                              height: 1,
-                              color: const Color(0xFFEEEEEE),
-                            ),
-                          ),
+                              child: Container(
+                                  height: 1,
+                                  color: const Color(0xFFEEEEEE))),
                         ],
                       ),
                     ),
 
-                    // 최종 자산
+                    // 최종 자산 (카운트업)
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          '최종 자산',
-                          style: TextStyle(fontSize: 14, color: Color(0xFF6B7684)),
-                        ),
-                        Text(
-                          '₩${_formatNumber(_finalAsset)}',
-                          style: TextStyle(
-                            fontSize: 20,
-                            fontWeight: FontWeight.w800,
-                            color: color,
+                        const Text('최종 자산',
+                            style: TextStyle(
+                                fontSize: 14,
+                                color: Color(0xFF6B7684))),
+                        AnimatedBuilder(
+                          animation: _assetAnim,
+                          builder: (_, __) => Text(
+                            '₩${_formatNumber(_assetAnim.value)}',
+                            style: TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.w800,
+                                color: color),
                           ),
                         ),
                       ],
@@ -168,33 +216,42 @@ class GameResultScreen extends StatelessWidget {
 
               const SizedBox(height: 16),
 
-              // 수익률 뱃지
+              // 수익률 뱃지 (카운트업)
               Container(
                 width: double.infinity,
                 padding: const EdgeInsets.symmetric(vertical: 18),
                 decoration: BoxDecoration(
                   color: color.withValues(alpha: 0.08),
                   borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: color.withValues(alpha: 0.2), width: 1),
+                  border: Border.all(
+                      color: color.withValues(alpha: 0.2), width: 1),
                 ),
                 child: Column(
                   children: [
-                    Text(
-                      '${profit ? '+' : ''}${returnRate.toStringAsFixed(2)}%',
-                      style: TextStyle(
-                        fontSize: 36,
-                        fontWeight: FontWeight.w800,
-                        color: color,
-                      ),
+                    AnimatedBuilder(
+                      animation: _returnAnim,
+                      builder: (_, __) {
+                        final val     = _returnAnim.value;
+                        final animPos = val >= 0;
+                        final animColor = animPos
+                            ? const Color(0xFFE03131)
+                            : const Color(0xFF1971C2);
+                        return Text(
+                          '${animPos ? '+' : ''}${val.toStringAsFixed(2)}%',
+                          style: TextStyle(
+                              fontSize: 36,
+                              fontWeight: FontWeight.w800,
+                              color: animColor),
+                        );
+                      },
                     ),
                     const SizedBox(height: 4),
                     Text(
                       profit ? '수익을 달성했어요 🎉' : '손실이 발생했어요',
                       style: TextStyle(
-                        fontSize: 14,
-                        color: color.withValues(alpha: 0.8),
-                        fontWeight: FontWeight.w500,
-                      ),
+                          fontSize: 14,
+                          color: color.withValues(alpha: 0.8),
+                          fontWeight: FontWeight.w500),
                     ),
                   ],
                 ),
@@ -208,21 +265,19 @@ class GameResultScreen extends StatelessWidget {
                 height: 52,
                 child: ElevatedButton(
                   onPressed: () {
-                    // 시나리오 선택 화면까지 전부 pop
-                    Navigator.of(context).popUntil((route) => route.isFirst);
+                    Navigator.of(context)
+                        .popUntil((route) => route.isFirst);
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: const Color(0xFF111111),
                     foregroundColor: Colors.white,
                     elevation: 0,
                     shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
-                    ),
+                        borderRadius: BorderRadius.circular(14)),
                   ),
-                  child: const Text(
-                    '다시 시작하기',
-                    style: TextStyle(fontSize: 15, fontWeight: FontWeight.w700),
-                  ),
+                  child: const Text('다시 시작하기',
+                      style: TextStyle(
+                          fontSize: 15, fontWeight: FontWeight.w700)),
                 ),
               ),
             ],
@@ -231,4 +286,6 @@ class GameResultScreen extends StatelessWidget {
       ),
     );
   }
+
+
 }

--- a/frontEnd/lib/screens/game_screen.dart
+++ b/frontEnd/lib/screens/game_screen.dart
@@ -12,7 +12,6 @@ import '../widgets/stock_chart.dart';
 import '../widgets/holdings_widget.dart';
 import 'game_result_screen.dart';
 
-// AI 추천 버튼 상태
 enum AiState { idle, loading, done, error }
 
 class GameScreen extends StatefulWidget {
@@ -23,7 +22,7 @@ class GameScreen extends StatefulWidget {
   State<GameScreen> createState() => _GameScreenState();
 }
 
-class _GameScreenState extends State<GameScreen> {
+class _GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
   final GameService _gameService = GameService();
 
   late GameSession _session;
@@ -34,20 +33,29 @@ class _GameScreenState extends State<GameScreen> {
 
   List<int> _currentCardOptions = [];
 
-  // 이미 선택한 카드 누적 (V2 alreadyCards 파라미터용)
+  // 선택한 카드 누적 (보유카드 + V2 alreadyCards용)
   final List<int> _selectedCardIds = [];
   int? _lastAddedCardId;
 
-  // V1.5: 게임 시작 후 백그라운드 로딩
-  Map<int, int> _v1RecommendedCards = {}; // {라운드: cardId}
+  // 이번 라운드 발동 카드 (애니메이션용)
+  List<int> _triggeredCardIds = [];
 
-  // V2: AI 추천받기 버튼 눌렀을 때만 동작
+  // V1.5: 백그라운드 로딩
+  Map<int, int> _v1RecommendedCards = {};
+
+  // V2: 버튼 눌렀을 때만
   AiState          _aiState             = AiState.idle;
   int?             _v2RecommendedCardId;
-  Map<int, double> _contributions       = {}; // {cardId: contribution}
+  Map<int, double> _contributions       = {};
   bool             _aiRequested         = false;
 
   Timer? _autoTimer;
+
+  // 총 자산 카운트업 애니메이션
+  late AnimationController _assetAnimController;
+  late Animation<double>   _assetAnim;
+  double _prevAsset = 0;
+  double _targetAsset = 0;
 
   // ── Getters ────────────────────────────────
   RoundData get _currentRound {
@@ -75,17 +83,17 @@ class _GameScreenState extends State<GameScreen> {
     return _currentRoundIndex >= _session.rounds.length - 1;
   }
 
-  // V2 사용 가능한 라운드: 25·50만 (75 역상관 제외)
+  // V2: 25·50라운드만 (1·75 제외)
   bool get _canUseV2 => [25, 50].contains(_currentRound1);
 
-  // AI 추천 카드 ID (V2 우선, 없으면 V1.5)
+  // AI 추천 카드 ID
   int? get _aiRecommendedCardId {
     if (!_aiRequested || _aiState != AiState.done) return null;
     return _v2RecommendedCardId ?? _v1RecommendedCards[_currentRound1];
   }
 
-  // 보유 종목 데이터
-  List<HoldingInfo> get _holdings => extractHoldings(
+  // 보유카드 데이터
+  List<HoldingCardInfo> get _holdingCards => extractHoldingCards(
         selectedCardIds:   _selectedCardIds,
         rounds:            _session.rounds,
         currentRoundIndex: _currentRoundIndex,
@@ -100,12 +108,28 @@ class _GameScreenState extends State<GameScreen> {
     super.initState();
     _session            = widget.session;
     _currentCardOptions = _session.firstCardOptions;
+
+    final initAsset = _session.initialAsset.toDouble();
+    _prevAsset   = initAsset;
+    _targetAsset = initAsset;
+
+    _assetAnimController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    );
+    _assetAnim = Tween<double>(begin: initAsset, end: initAsset)
+        .animate(CurvedAnimation(
+          parent: _assetAnimController,
+          curve: Curves.easeOut,
+        ));
+
     _loadV1InBackground();
   }
 
   @override
   void dispose() {
     _autoTimer?.cancel();
+    _assetAnimController.dispose();
     super.dispose();
   }
 
@@ -122,16 +146,16 @@ class _GameScreenState extends State<GameScreen> {
           _v1RecommendedCards[rec.round] = rec.cardId;
         }
       });
-    }).catchError((_) {
-      // V1.5 실패해도 게임 진행 가능
-    });
+    }).catchError((_) {});
   }
 
   // =============================================
-  // V2 AI 추천 (버튼 클릭 시)
+  // V2 AI 추천 (버튼 클릭 시, 25·50라운드만)
   // =============================================
   Future<void> _requestAiRecommendation() async {
     if (_aiState == AiState.loading) return;
+    // 1·75라운드에서는 버튼 자체가 없음 → 호출 안 됨
+
     setState(() {
       _aiRequested         = true;
       _aiState             = AiState.loading;
@@ -140,29 +164,22 @@ class _GameScreenState extends State<GameScreen> {
     });
 
     try {
-      if (_canUseV2) {
-        final result = await _gameService.getV2Recommendation(
-          sessionId:      _session.sessionId,
-          currentRound:   _currentRound1,
-          alreadyCards:   List.from(_selectedCardIds),
-          candidateCards: List.from(_currentCardOptions),
-        );
-        if (!mounted) return;
-        final contribs = <int, double>{};
-        for (final r in result.rankings) {
-          contribs[r.cardId] = r.contribution;
-        }
-        setState(() {
-          _v2RecommendedCardId = result.recommendedCardId;
-          _contributions       = contribs;
-          _aiState             = AiState.done;
-        });
-      } else {
-        // 1·75라운드: V1.5 사전 추천 사용
-        await Future.delayed(const Duration(milliseconds: 300));
-        if (!mounted) return;
-        setState(() => _aiState = AiState.done);
+      final result = await _gameService.getV2Recommendation(
+        sessionId:      _session.sessionId,
+        currentRound:   _currentRound1,
+        alreadyCards:   List.from(_selectedCardIds),
+        candidateCards: List.from(_currentCardOptions),
+      );
+      if (!mounted) return;
+      final contribs = <int, double>{};
+      for (final r in result.rankings) {
+        contribs[r.cardId] = r.contribution;
       }
+      setState(() {
+        _v2RecommendedCardId = result.recommendedCardId;
+        _contributions       = contribs;
+        _aiState             = AiState.done;
+      });
     } catch (_) {
       if (!mounted) return;
       setState(() => _aiState = AiState.error);
@@ -190,12 +207,18 @@ class _GameScreenState extends State<GameScreen> {
         if (!_isLastRound) {
           setState(() {
             _currentRoundIndex++;
-            _cardSelected = false;
+            _cardSelected    = false;
+            _triggeredCardIds = [];
             _resetAiState();
           });
         }
       } else {
-        setState(() => _currentRoundIndex++);
+        setState(() {
+          _currentRoundIndex++;
+          _triggeredCardIds =
+              _session.rounds[_currentRoundIndex].triggeredCards;
+        });
+        _animateAsset();
       }
     });
   }
@@ -211,23 +234,41 @@ class _GameScreenState extends State<GameScreen> {
     final next = _currentRoundIndex + 2;
     setState(() {
       _currentRoundIndex++;
+      _triggeredCardIds =
+          _session.rounds[_currentRoundIndex].triggeredCards;
       if (_session.isCardSelectRound(next)) {
-        _cardSelected = false;
+        _cardSelected    = false;
+        _triggeredCardIds = [];
         _resetAiState();
       }
     });
+    _animateAsset();
+  }
+
+  void _animateAsset() {
+    final round      = _currentRound;
+    final newAsset   = round.roundAsset ?? _session.initialAsset.toDouble();
+    final fromAsset  = _assetAnim.value;
+
+    _assetAnim = Tween<double>(begin: fromAsset, end: newAsset)
+        .animate(CurvedAnimation(
+          parent: _assetAnimController,
+          curve: Curves.easeOut,
+        ));
+    _assetAnimController.forward(from: 0);
   }
 
   void _goToResult() {
     _stopAutoPlay();
     Navigator.pushReplacement(
       context,
-      MaterialPageRoute(builder: (_) => GameResultScreen(session: _session)),
+      MaterialPageRoute(
+          builder: (_) => GameResultScreen(session: _session)),
     );
   }
 
   // =============================================
-  // 카드 선택 API
+  // 카드 선택
   // =============================================
   Future<void> _onCardSelected(int cardId) async {
     setState(() => _isSubmitting = true);
@@ -289,7 +330,8 @@ class _GameScreenState extends State<GameScreen> {
       if (!_selectedCardIds.contains(selectedCardId)) {
         _selectedCardIds.add(selectedCardId);
       }
-      _lastAddedCardId = selectedCardId;
+      _lastAddedCardId  = selectedCardId;
+      _triggeredCardIds = [];
       _resetAiState();
     });
   }
@@ -305,6 +347,7 @@ class _GameScreenState extends State<GameScreen> {
       _currentCardOptions = mockSession.firstCardOptions;
       _selectedCardIds.clear();
       _lastAddedCardId    = null;
+      _triggeredCardIds   = [];
       _resetAiState();
     });
   }
@@ -328,24 +371,30 @@ class _GameScreenState extends State<GameScreen> {
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(20, 6, 20, 20),
                 child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
+                    // 차트 (고정 비율)
                     _buildChartArea(),
                     const SizedBox(height: 8),
+
+                    // 라운드 정보 (내 수익률 | 총 자산 박스)
                     _buildRoundInfo(),
                     const SizedBox(height: 8),
-                    if (_showCard) ...[
-                      if (_selectedCardIds.isNotEmpty) ...[
-                        HoldingsMiniGrid(holdings: _holdings),
-                        const SizedBox(height: 8),
-                      ],
-                      _buildCardSelector(),
-                    ] else ...[
-                      if (_selectedCardIds.isNotEmpty) ...[
-                        HoldingsGameWidget(holdings: _holdings),
-                        const SizedBox(height: 8),
-                      ],
-                      _buildControls(),
+
+                    // 보유카드 (항상 동일한 위젯)
+                    if (_selectedCardIds.isNotEmpty) ...[
+                      HoldingCardsWidget(
+                        cards:           _holdingCards,
+                        triggeredCardIds: _triggeredCardIds,
+                      ),
+                      const SizedBox(height: 8),
                     ],
+
+                    // 카드 선택 or 컨트롤
+                    if (_showCard)
+                      _buildCardSelector()
+                    else
+                      _buildControls(),
                   ],
                 ),
               ),
@@ -376,7 +425,8 @@ class _GameScreenState extends State<GameScreen> {
                     color: Color(0xFF111111))),
           ),
           Container(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            padding: const EdgeInsets.symmetric(
+                horizontal: 10, vertical: 4),
             decoration: BoxDecoration(
               color: const Color(0xFFEEEDFE),
               borderRadius: BorderRadius.circular(20),
@@ -451,17 +501,18 @@ class _GameScreenState extends State<GameScreen> {
     );
   }
 
-  // ── 차트 (수익률%) ─────────────────────────
+  // ── 차트 ──────────────────────────────────
   Widget _buildChartArea() {
-    return Expanded(
-      flex: 7,
+    return SizedBox(
+      height: 160,
       child: Container(
         width: double.infinity,
-        padding: const EdgeInsets.fromLTRB(8, 12, 12, 8),
+        padding: const EdgeInsets.fromLTRB(8, 8, 12, 6),
         decoration: BoxDecoration(
           color: Colors.white,
           borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
+          border: Border.all(
+              color: const Color(0xFFEEEEEE), width: 1),
         ),
         child: StockChart(
           rounds:       _chartData,
@@ -471,158 +522,93 @@ class _GameScreenState extends State<GameScreen> {
     );
   }
 
-  // ── 라운드 정보 ────────────────────────────
+  // ── 라운드 정보 (개선안 B - 박스 분리) ────────
   Widget _buildRoundInfo() {
     final round      = _currentRound;
-    final asset      = round.roundAsset ?? _session.initialAsset.toDouble();
     final returnRate = round.returnRate;
     final isPos      = (returnRate ?? 0) >= 0;
 
-    // 시장 대비 우위 계산
-    double? spxReturnRate;
-    final spxBase = _session.rounds.isNotEmpty
-        ? _session.rounds.first.getPrice('^SPX')?.close
-        : null;
-    final spxNow = round.getPrice('^SPX')?.close;
-    if (spxBase != null && spxNow != null && spxBase > 0) {
-      spxReturnRate = (spxNow - spxBase) / spxBase * 100;
-    }
-    final beatMarket = returnRate != null &&
-        spxReturnRate != null &&
-        returnRate > spxReturnRate;
-
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
-      ),
-      child: Column(
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(round.date,
-                        style: const TextStyle(
-                            fontSize: 12, color: Color(0xFF6B7684))),
-                    const SizedBox(height: 4),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 4,
-                      children: round.priceData.map((price) {
-                        final pos = price.changeRate >= 0;
-                        return Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Container(
-                              width: 8, height: 8,
-                              decoration: BoxDecoration(
-                                color: _tickerColor(price.ticker),
-                                shape: BoxShape.circle,
-                              ),
-                            ),
-                            const SizedBox(width: 4),
-                            Text(
-                              '${price.ticker} ${pos ? '+' : ''}${price.changeRate.toStringAsFixed(2)}%',
-                              style: TextStyle(
-                                  fontSize: 11,
-                                  fontWeight: FontWeight.w600,
-                                  color: pos
-                                      ? const Color(0xFFE03131)
-                                      : const Color(0xFF1971C2)),
-                            ),
-                          ],
-                        );
-                      }).toList(),
-                    ),
-                  ],
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // 내 수익률 박스
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+                horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(
+                  color: const Color(0xFFEEEEEE), width: 1),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  '내 수익률',
+                  style: TextStyle(
+                      fontSize: 10, color: Color(0xFF6B7684)),
                 ),
-              ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  Text('${_formatNumber(asset)}원',
-                      style: const TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w700,
-                          color: Color(0xFF111111))),
-                  if (returnRate != null) ...[
-                    const SizedBox(height: 2),
-                    Text(
-                      '${isPos ? '+' : ''}${returnRate.toStringAsFixed(2)}%',
-                      style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600,
-                          color: isPos
-                              ? const Color(0xFFE03131)
-                              : const Color(0xFF1971C2)),
-                    ),
-                  ],
-                ],
-              ),
-            ],
+                const SizedBox(height: 4),
+                Text(
+                  returnRate != null
+                      ? '${isPos ? '+' : ''}${returnRate.toStringAsFixed(2)}%'
+                      : '0.00%',
+                  style: TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w700,
+                      color: isPos
+                          ? const Color(0xFFE03131)
+                          : const Color(0xFF1971C2)),
+                ),
+              ],
+            ),
           ),
-
-          // 시장 대비 배너
-          if (returnRate != null && spxReturnRate != null) ...[
-            const SizedBox(height: 6),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.symmetric(
-                  horizontal: 10, vertical: 4),
-              decoration: BoxDecoration(
-                color: beatMarket
-                    ? const Color(0xFFE6F9F0)
-                    : const Color(0xFFFFF0F0),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Text(
-                beatMarket
-                    ? '▲ 시장 대비 +${(returnRate - spxReturnRate).toStringAsFixed(1)}%p 우위'
-                    : '▼ 시장 대비 ${(returnRate - spxReturnRate).toStringAsFixed(1)}%p 뒤처짐',
-                style: TextStyle(
-                    fontSize: 11,
-                    fontWeight: FontWeight.w600,
-                    color: beatMarket
-                        ? const Color(0xFF0F6E56)
-                        : const Color(0xFFE03131)),
-                textAlign: TextAlign.center,
-              ),
+        ),
+        const SizedBox(width: 8),
+        // 총 자산 박스
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+                horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(
+                  color: const Color(0xFFEEEEEE), width: 1),
             ),
-          ],
-
-          // 발동 카드
-          if (round.triggeredCards.isNotEmpty) ...[
-            const SizedBox(height: 8),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.symmetric(
-                  horizontal: 10, vertical: 6),
-              decoration: BoxDecoration(
-                color: const Color(0xFFEEEDFE),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Wrap(
-                spacing: 6,
-                children: round.triggeredCards.map((id) {
-                  final card = CardInfo.fromId(id);
-                  if (card == null) return const SizedBox.shrink();
-                  return Text('${card.emoji} ${card.name} 발동',
-                      style: const TextStyle(
-                          fontSize: 11,
-                          fontWeight: FontWeight.w600,
-                          color: Color(0xFF3C3489)));
-                }).toList(),
-              ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  '총 자산',
+                  style: TextStyle(
+                      fontSize: 10, color: Color(0xFF6B7684)),
+                ),
+                const SizedBox(height: 4),
+                AnimatedBuilder(
+                  animation: _assetAnim,
+                  builder: (_, __) => Text(
+                    '${_formatNumber(_assetAnim.value)}원',
+                    style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                        color: Color(0xFF111111)),
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(round.date,
+                    style: const TextStyle(
+                        fontSize: 10,
+                        color: Color(0xFF6B7684))),
+              ],
             ),
-          ],
-        ],
-      ),
+          ),
+        ),
+      ],
     );
   }
 
@@ -647,7 +633,8 @@ class _GameScreenState extends State<GameScreen> {
                       fontWeight: FontWeight.w600,
                       color: Color(0xFF6B7684))),
               const Spacer(),
-              _buildAiButton(),
+              // AI 버튼: 25·50라운드만 표시
+              if (_canUseV2) _buildAiButton(),
             ],
           ),
 
@@ -672,19 +659,23 @@ class _GameScreenState extends State<GameScreen> {
 
           const SizedBox(height: 10),
 
-          Row(
-            children: _currentCardOptions.asMap().entries.map((e) {
-              final cardId = e.value;
-              final last   = e.key == _currentCardOptions.length - 1;
-              final card   = CardInfo.fromId(cardId);
-              if (card == null) return const SizedBox.shrink();
-              return Expanded(
-                child: Padding(
-                  padding: EdgeInsets.only(right: last ? 0 : 8),
-                  child: _buildCardItem(card),
-                ),
-              );
-            }).toList(),
+          // 카드 3개: 균등 패딩
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: List.generate(_currentCardOptions.length, (i) {
+                final cardId = _currentCardOptions[i];
+                final card   = CardInfo.fromId(cardId);
+                if (card == null) return const SizedBox.shrink();
+                final isLast = i == _currentCardOptions.length - 1;
+                return Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.only(right: isLast ? 0 : 8),
+                    child: _buildCardItem(card),
+                  ),
+                );
+              }),
+            ),
           ),
         ],
       ),
@@ -795,81 +786,80 @@ class _GameScreenState extends State<GameScreen> {
 
   // ── 카드 아이템 ────────────────────────────
   Widget _buildCardItem(CardInfo card) {
-    final aiPick       = _aiRecommendedCardId == card.id;
+    final aiPick      = _aiRecommendedCardId == card.id;
     final contribution = _contributions[card.id];
     final showContrib  =
         _aiRequested && _aiState == AiState.done && contribution != null;
 
     return GestureDetector(
       onTap: _isSubmitting ? null : () => _onCardSelected(card.id),
-      child: Stack(
-        children: [
-          Container(
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: aiPick
-                  ? const Color(0xFFDEDCFD)
-                  : const Color(0xFFEEEDFE),
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: aiPick
-                    ? const Color(0xFF3C3489)
-                    : const Color(0xFF534AB7),
-                width: aiPick ? 2 : 1,
-              ),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(card.emoji,
-                    style: const TextStyle(fontSize: 22)),
-                const SizedBox(height: 6),
-                Text(card.name,
-                    style: const TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.w700,
-                        color: Color(0xFF3C3489))),
-                const SizedBox(height: 4),
-                Text(card.description,
-                    style: const TextStyle(
-                        fontSize: 10,
-                        color: Color(0xFF534AB7),
-                        height: 1.4)),
-                // 기여도: 버튼 눌러서 완료됐을 때만
-                if (showContrib) ...[
-                  const SizedBox(height: 6),
-                  Text(
-                    '${contribution >= 0 ? '+' : ''}${contribution.toStringAsFixed(2)}%',
-                    style: TextStyle(
-                        fontSize: 11,
-                        fontWeight: FontWeight.w700,
-                        color: contribution >= 0
-                            ? const Color(0xFF0F6E56)
-                            : const Color(0xFF993C1D)),
-                  ),
-                ],
-              ],
-            ),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: const Color(0xFFEEEDFE),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: const Color(0xFF534AB7),
+            width: 1,
           ),
-          // AI 추천 뱃지
-          if (aiPick)
-            Positioned(
-              top: 4, right: 4,
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 6, vertical: 2),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF3C3489),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: const Text('AI 추천',
-                    style: TextStyle(
-                        fontSize: 9,
-                        fontWeight: FontWeight.w700,
-                        color: Colors.white)),
-              ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 상단 영역: 뱃지 있든 없든 동일 높이 확보
+            SizedBox(
+              height: 20,
+              child: aiPick
+                  ? Align(
+                      alignment: Alignment.centerRight,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFFE03131),
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                        child: const Text('AI 추천',
+                            style: TextStyle(
+                                fontSize: 9,
+                                fontWeight: FontWeight.w700,
+                                color: Colors.white)),
+                      ),
+                    )
+                  : const SizedBox.shrink(),
             ),
-        ],
+            const SizedBox(height: 2),
+
+            Text(card.emoji,
+                style: const TextStyle(fontSize: 22)),
+            const SizedBox(height: 6),
+            Text(card.name,
+                style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: Color(0xFF3C3489))),
+            const SizedBox(height: 4),
+            Text(card.description,
+                style: const TextStyle(
+                    fontSize: 10,
+                    color: Color(0xFF534AB7),
+                    height: 1.4)),
+
+            // 기여도: 추천 완료 후에만
+            if (showContrib) ...[
+              const SizedBox(height: 6),
+              Text(
+                '${contribution >= 0 ? '+' : ''}${contribution.toStringAsFixed(2)}%',
+                style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    color: contribution >= 0
+                        ? const Color(0xFF0F6E56)
+                        : const Color(0xFF993C1D)),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }
@@ -935,18 +925,6 @@ class _GameScreenState extends State<GameScreen> {
   }
 
   // ── 유틸 ──────────────────────────────────
-  Color _tickerColor(String ticker) {
-    const colors = {
-      '^SPX': Color(0xFF1971C2),
-      '^NDX': Color(0xFF7048E8),
-      'GLD':  Color(0xFFE67700),
-      'USO':  Color(0xFF2F9E44),
-      'AAPL': Color(0xFF868E96),
-      'TLT':  Color(0xFFE64980),
-    };
-    return colors[ticker] ?? const Color(0xFF6B7684);
-  }
-
   String _formatNumber(double value) {
     return value
         .toStringAsFixed(0)

--- a/frontEnd/lib/screens/game_screen.dart
+++ b/frontEnd/lib/screens/game_screen.dart
@@ -4,10 +4,16 @@ import '../models/game_session.dart';
 import '../models/round_data.dart';
 import '../models/action_result.dart';
 import '../models/card_info.dart';
+import '../models/v1_recommend_result.dart';
+import '../models/v2_recommend_result.dart';
 import '../services/game_service.dart';
 import '../services/mock_data.dart';
 import '../widgets/stock_chart.dart';
+import '../widgets/holdings_widget.dart';
 import 'game_result_screen.dart';
+
+// AI 추천 버튼 상태
+enum AiState { idle, loading, done, error }
 
 class GameScreen extends StatefulWidget {
   final GameSession session;
@@ -21,27 +27,37 @@ class _GameScreenState extends State<GameScreen> {
   final GameService _gameService = GameService();
 
   late GameSession _session;
-  int _currentRoundIndex = 0;
+  int  _currentRoundIndex = 0;
+  bool _cardSelected      = false;
+  bool _isSubmitting      = false;
+  bool _isAutoPlaying     = false;
 
-  bool _cardSelected = false;
-  bool _isSubmitting = false;
-  bool _isAutoPlaying = false;
-
-  // 현재 표시할 카드 선택지
   List<int> _currentCardOptions = [];
+
+  // 이미 선택한 카드 누적 (V2 alreadyCards 파라미터용)
+  final List<int> _selectedCardIds = [];
+  int? _lastAddedCardId;
+
+  // V1.5: 게임 시작 후 백그라운드 로딩
+  Map<int, int> _v1RecommendedCards = {}; // {라운드: cardId}
+
+  // V2: AI 추천받기 버튼 눌렀을 때만 동작
+  AiState          _aiState             = AiState.idle;
+  int?             _v2RecommendedCardId;
+  Map<int, double> _contributions       = {}; // {cardId: contribution}
+  bool             _aiRequested         = false;
 
   Timer? _autoTimer;
 
+  // ── Getters ────────────────────────────────
   RoundData get _currentRound {
-    final index = _currentRoundIndex.clamp(0, _session.rounds.length - 1);
-    return _session.rounds[index];
+    final idx = _currentRoundIndex.clamp(0, _session.rounds.length - 1);
+    return _session.rounds[idx];
   }
 
   List<RoundData> get _chartData => _session.getChartData(
-        _currentRoundIndex.clamp(0, _session.rounds.length - 1),
-      );
+      _currentRoundIndex.clamp(0, _session.rounds.length - 1));
 
-  // 현재 라운드 번호 (1-based)
   int get _currentRound1 => _currentRoundIndex + 1;
 
   bool get _showCard {
@@ -54,16 +70,37 @@ class _GameScreenState extends State<GameScreen> {
 
   bool get _isLastRound {
     if (!_cardSelected) return false;
-    final nextRound = _currentRoundIndex + 2;
-    if (_session.isCardSelectRound(nextRound)) return false;
+    final next = _currentRoundIndex + 2;
+    if (_session.isCardSelectRound(next)) return false;
     return _currentRoundIndex >= _session.rounds.length - 1;
   }
 
+  // V2 사용 가능한 라운드: 25·50만 (75 역상관 제외)
+  bool get _canUseV2 => [25, 50].contains(_currentRound1);
+
+  // AI 추천 카드 ID (V2 우선, 없으면 V1.5)
+  int? get _aiRecommendedCardId {
+    if (!_aiRequested || _aiState != AiState.done) return null;
+    return _v2RecommendedCardId ?? _v1RecommendedCards[_currentRound1];
+  }
+
+  // 보유 종목 데이터
+  List<HoldingInfo> get _holdings => extractHoldings(
+        selectedCardIds:   _selectedCardIds,
+        rounds:            _session.rounds,
+        currentRoundIndex: _currentRoundIndex,
+        newCardId:         _lastAddedCardId,
+      );
+
+  // =============================================
+  // 생명주기
+  // =============================================
   @override
   void initState() {
     super.initState();
-    _session = widget.session;
+    _session            = widget.session;
     _currentCardOptions = _session.firstCardOptions;
+    _loadV1InBackground();
   }
 
   @override
@@ -72,20 +109,89 @@ class _GameScreenState extends State<GameScreen> {
     super.dispose();
   }
 
-  // ── 자동 진행 ──────────────────────────────
+  // =============================================
+  // V1.5 백그라운드 로딩
+  // =============================================
+  void _loadV1InBackground() {
+    _gameService.getV1Recommendation(
+      sessionId: _session.sessionId,
+    ).then((result) {
+      if (!mounted) return;
+      setState(() {
+        for (final rec in result.recommendations) {
+          _v1RecommendedCards[rec.round] = rec.cardId;
+        }
+      });
+    }).catchError((_) {
+      // V1.5 실패해도 게임 진행 가능
+    });
+  }
+
+  // =============================================
+  // V2 AI 추천 (버튼 클릭 시)
+  // =============================================
+  Future<void> _requestAiRecommendation() async {
+    if (_aiState == AiState.loading) return;
+    setState(() {
+      _aiRequested         = true;
+      _aiState             = AiState.loading;
+      _v2RecommendedCardId = null;
+      _contributions       = {};
+    });
+
+    try {
+      if (_canUseV2) {
+        final result = await _gameService.getV2Recommendation(
+          sessionId:      _session.sessionId,
+          currentRound:   _currentRound1,
+          alreadyCards:   List.from(_selectedCardIds),
+          candidateCards: List.from(_currentCardOptions),
+        );
+        if (!mounted) return;
+        final contribs = <int, double>{};
+        for (final r in result.rankings) {
+          contribs[r.cardId] = r.contribution;
+        }
+        setState(() {
+          _v2RecommendedCardId = result.recommendedCardId;
+          _contributions       = contribs;
+          _aiState             = AiState.done;
+        });
+      } else {
+        // 1·75라운드: V1.5 사전 추천 사용
+        await Future.delayed(const Duration(milliseconds: 300));
+        if (!mounted) return;
+        setState(() => _aiState = AiState.done);
+      }
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _aiState = AiState.error);
+    }
+  }
+
+  void _resetAiState() {
+    _aiState             = AiState.idle;
+    _aiRequested         = false;
+    _v2RecommendedCardId = null;
+    _contributions       = {};
+  }
+
+  // =============================================
+  // 자동 진행
+  // =============================================
   void _startAutoPlay() {
     setState(() => _isAutoPlaying = true);
     _autoTimer = Timer.periodic(const Duration(milliseconds: 500), (_) {
       if (!mounted) return;
-      final nextRound = _currentRoundIndex + 2;
-      final willHitCard = _session.isCardSelectRound(nextRound);
-
+      final next        = _currentRoundIndex + 2;
+      final willHitCard = _session.isCardSelectRound(next);
       if (_isLastRound || willHitCard) {
         _stopAutoPlay();
         if (!_isLastRound) {
           setState(() {
             _currentRoundIndex++;
             _cardSelected = false;
+            _resetAiState();
           });
         }
       } else {
@@ -100,71 +206,60 @@ class _GameScreenState extends State<GameScreen> {
     if (mounted) setState(() => _isAutoPlaying = false);
   }
 
-  // ── 다음 라운드 (수동) ──────────────────────
   void _nextRound() {
     if (_isLastRound) return;
-    final nextRound = _currentRoundIndex + 2;
+    final next = _currentRoundIndex + 2;
     setState(() {
       _currentRoundIndex++;
-      if (_session.isCardSelectRound(nextRound)) {
+      if (_session.isCardSelectRound(next)) {
         _cardSelected = false;
+        _resetAiState();
       }
     });
   }
 
-  // ── 게임 종료 → 결과 화면 ───────────────────
   void _goToResult() {
     _stopAutoPlay();
     Navigator.pushReplacement(
       context,
-      MaterialPageRoute(
-        builder: (_) => GameResultScreen(session: _session),
-      ),
+      MaterialPageRoute(builder: (_) => GameResultScreen(session: _session)),
     );
   }
 
-  // ── 카드 선택 (실제 API) ────────────────────
+  // =============================================
+  // 카드 선택 API
+  // =============================================
   Future<void> _onCardSelected(int cardId) async {
     setState(() => _isSubmitting = true);
     try {
       final result = await _gameService.submitAction(
         sessionId: _session.sessionId,
-        round: _currentRound1,
-        cardId: cardId,
+        round:     _currentRound1,
+        cardId:    cardId,
       );
-      _applyActionResult(result);
+      _applyActionResult(result, cardId);
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(e.toString()),
+        content:         Text(e.toString()),
         backgroundColor: Colors.red[700],
-        behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        behavior:        SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10)),
       ));
     } finally {
       if (mounted) setState(() => _isSubmitting = false);
     }
   }
 
-  // ── 카드 선택 (Mock) ────────────────────────
   void _onMockCardSelected(int cardId) {
     final mockData = MockData.getActionResult(_currentRoundIndex);
-    final result = ActionResult.fromJson(
-      mockData['data'] as Map<String, dynamic>,
-    );
-    _applyActionResult(result);
+    final result   = ActionResult.fromJson(
+        mockData['data'] as Map<String, dynamic>);
+    _applyActionResult(result, cardId);
   }
 
-  // ── ActionResult 반영 ───────────────────────
-  void _applyActionResult(ActionResult result) {
-    print('=== ActionResult ===');
-    print('nextEventRound: ${result.nextEventRound}');
-    print('nextCardOptions: ${result.nextCardOptions}');
-    print('rounds count: ${result.rounds.length}');
-    if (result.rounds.isNotEmpty) {
-      print('rounds: ${result.rounds.first.round} ~ ${result.rounds.last.round}');
-    }
-
+  void _applyActionResult(ActionResult result, int selectedCardId) {
     final updatedRounds = List<RoundData>.from(_session.rounds);
     for (final newRound in result.rounds) {
       final index = newRound.round - 1;
@@ -187,26 +282,36 @@ class _GameScreenState extends State<GameScreen> {
         firstCardOptions: _session.firstCardOptions,
         rounds:           updatedRounds,
       );
-      _cardSelected = true;
+      _cardSelected       = true;
       _currentCardOptions = result.nextCardOptions;
+
+      // 선택한 카드 누적
+      if (!_selectedCardIds.contains(selectedCardId)) {
+        _selectedCardIds.add(selectedCardId);
+      }
+      _lastAddedCardId = selectedCardId;
+      _resetAiState();
     });
   }
 
-  // ── Mock 세션 초기화 ────────────────────────
   void _loadMockSession() {
     _stopAutoPlay();
     final mockSession = GameSession.fromJson(
-      MockData.gameSession['data'] as Map<String, dynamic>,
-    );
+        MockData.gameSession['data'] as Map<String, dynamic>);
     setState(() {
-      _session = mockSession;
-      _currentRoundIndex = 0;
-      _cardSelected = false;
+      _session            = mockSession;
+      _currentRoundIndex  = 0;
+      _cardSelected       = false;
       _currentCardOptions = mockSession.firstCardOptions;
+      _selectedCardIds.clear();
+      _lastAddedCardId    = null;
+      _resetAiState();
     });
   }
 
-  // ── Build ───────────────────────────────────
+  // =============================================
+  // Build
+  // =============================================
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -221,16 +326,26 @@ class _GameScreenState extends State<GameScreen> {
             ),
             Expanded(
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(20, 10, 20, 20),
+                padding: const EdgeInsets.fromLTRB(20, 6, 20, 20),
                 child: Column(
                   children: [
                     _buildChartArea(),
-                    const SizedBox(height: 10),
+                    const SizedBox(height: 8),
                     _buildRoundInfo(),
-                    const SizedBox(height: 10),
-                    _showCard
-                        ? _buildCardSelector()
-                        : _buildControls(),
+                    const SizedBox(height: 8),
+                    if (_showCard) ...[
+                      if (_selectedCardIds.isNotEmpty) ...[
+                        HoldingsMiniGrid(holdings: _holdings),
+                        const SizedBox(height: 8),
+                      ],
+                      _buildCardSelector(),
+                    ] else ...[
+                      if (_selectedCardIds.isNotEmpty) ...[
+                        HoldingsGameWidget(holdings: _holdings),
+                        const SizedBox(height: 8),
+                      ],
+                      _buildControls(),
+                    ],
                   ],
                 ),
               ),
@@ -241,7 +356,7 @@ class _GameScreenState extends State<GameScreen> {
     );
   }
 
-  // ── 헤더 ────────────────────────────────────
+  // ── 헤더 ──────────────────────────────────
   Widget _buildHeader() {
     return Container(
       padding: const EdgeInsets.fromLTRB(20, 16, 20, 10),
@@ -249,12 +364,16 @@ class _GameScreenState extends State<GameScreen> {
         children: [
           GestureDetector(
             onTap: () { _stopAutoPlay(); Navigator.pop(context); },
-            child: const Icon(Icons.arrow_back_ios_rounded, size: 18, color: Color(0xFF111111)),
+            child: const Icon(Icons.arrow_back_ios_rounded,
+                size: 18, color: Color(0xFF111111)),
           ),
           const SizedBox(width: 12),
           Expanded(
             child: Text(_session.scenarioTitle,
-              style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w700, color: Color(0xFF111111))),
+                style: const TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w700,
+                    color: Color(0xFF111111))),
           ),
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
@@ -262,17 +381,18 @@ class _GameScreenState extends State<GameScreen> {
               color: const Color(0xFFEEEDFE),
               borderRadius: BorderRadius.circular(20),
             ),
-            child: Text(
-              '$_currentRound1 / ${_session.totalRounds}',
-              style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: Color(0xFF3C3489)),
-            ),
+            child: Text('$_currentRound1 / ${_session.totalRounds}',
+                style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF3C3489))),
           ),
         ],
       ),
     );
   }
 
-  // ── 개발용 버튼 ─────────────────────────────
+  // ── 개발용 버튼 ────────────────────────────
   Widget _buildMockButton() {
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
@@ -284,14 +404,21 @@ class _GameScreenState extends State<GameScreen> {
       ),
       child: Row(
         children: [
-          const Text('개발용', style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600, color: Color(0xFF856404))),
+          const Text('개발용',
+              style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: Color(0xFF856404))),
           const SizedBox(width: 8),
           Expanded(child: _devBtn('세션 초기화', _loadMockSession)),
           const SizedBox(width: 6),
           Expanded(child: _devBtn(
             '임시 카드선택',
             !_cardSelected
-                ? () => _onMockCardSelected(_currentCardOptions.isNotEmpty ? _currentCardOptions[0] : 1)
+                ? () => _onMockCardSelected(
+                    _currentCardOptions.isNotEmpty
+                        ? _currentCardOptions[0]
+                        : 1)
                 : null,
           )),
           const SizedBox(width: 6),
@@ -307,18 +434,24 @@ class _GameScreenState extends State<GameScreen> {
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 6),
         decoration: BoxDecoration(
-          color: onTap == null ? const Color(0xFFEEEEEE) : const Color(0xFF111111),
+          color: onTap == null
+              ? const Color(0xFFEEEEEE)
+              : const Color(0xFF111111),
           borderRadius: BorderRadius.circular(7),
         ),
         child: Text(label,
-          textAlign: TextAlign.center,
-          style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600,
-            color: onTap == null ? const Color(0xFFAAAAAA) : Colors.white)),
+            textAlign: TextAlign.center,
+            style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+                color: onTap == null
+                    ? const Color(0xFFAAAAAA)
+                    : Colors.white)),
       ),
     );
   }
 
-  // ── 차트 영역 ───────────────────────────────
+  // ── 차트 (수익률%) ─────────────────────────
   Widget _buildChartArea() {
     return Expanded(
       flex: 7,
@@ -330,17 +463,33 @@ class _GameScreenState extends State<GameScreen> {
           borderRadius: BorderRadius.circular(16),
           border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
         ),
-        child: StockChart(rounds: _chartData),
+        child: StockChart(
+          rounds:       _chartData,
+          initialAsset: _session.initialAsset.toDouble(),
+        ),
       ),
     );
   }
 
-  // ── 라운드 정보 ─────────────────────────────
+  // ── 라운드 정보 ────────────────────────────
   Widget _buildRoundInfo() {
-    final round = _currentRound;
-    final asset = round.roundAsset ?? _session.initialAsset;
+    final round      = _currentRound;
+    final asset      = round.roundAsset ?? _session.initialAsset.toDouble();
     final returnRate = round.returnRate;
-    final isPos = (returnRate ?? 0) >= 0;
+    final isPos      = (returnRate ?? 0) >= 0;
+
+    // 시장 대비 우위 계산
+    double? spxReturnRate;
+    final spxBase = _session.rounds.isNotEmpty
+        ? _session.rounds.first.getPrice('^SPX')?.close
+        : null;
+    final spxNow = round.getPrice('^SPX')?.close;
+    if (spxBase != null && spxNow != null && spxBase > 0) {
+      spxReturnRate = (spxNow - spxBase) / spxBase * 100;
+    }
+    final beatMarket = returnRate != null &&
+        spxReturnRate != null &&
+        returnRate > spxReturnRate;
 
     return Container(
       width: double.infinity,
@@ -358,25 +507,38 @@ class _GameScreenState extends State<GameScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(round.date, style: const TextStyle(fontSize: 12, color: Color(0xFF6B7684))),
+                    Text(round.date,
+                        style: const TextStyle(
+                            fontSize: 12, color: Color(0xFF6B7684))),
                     const SizedBox(height: 4),
                     Wrap(
                       spacing: 8,
                       runSpacing: 4,
-                      children: round.priceData.map((price) => Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Container(width: 8, height: 8, decoration: BoxDecoration(
-                            color: tickerColor(price.ticker), shape: BoxShape.circle,
-                          )),
-                          const SizedBox(width: 4),
-                          Text(
-                            '${price.ticker} ${price.changeRate >= 0 ? '+' : ''}${price.changeRate.toStringAsFixed(2)}%',
-                            style: TextStyle(fontSize: 11, fontWeight: FontWeight.w600,
-                              color: price.isPositive ? const Color(0xFFE03131) : const Color(0xFF1971C2)),
-                          ),
-                        ],
-                      )).toList(),
+                      children: round.priceData.map((price) {
+                        final pos = price.changeRate >= 0;
+                        return Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Container(
+                              width: 8, height: 8,
+                              decoration: BoxDecoration(
+                                color: _tickerColor(price.ticker),
+                                shape: BoxShape.circle,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              '${price.ticker} ${pos ? '+' : ''}${price.changeRate.toStringAsFixed(2)}%',
+                              style: TextStyle(
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w600,
+                                  color: pos
+                                      ? const Color(0xFFE03131)
+                                      : const Color(0xFF1971C2)),
+                            ),
+                          ],
+                        );
+                      }).toList(),
                     ),
                   ],
                 ),
@@ -384,26 +546,63 @@ class _GameScreenState extends State<GameScreen> {
               Column(
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
-                  const Text('총자산', style: TextStyle(fontSize: 11, color: Color(0xFF6B7684))),
-                  Text('₩${_formatNumber(asset)}',
-                    style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Color(0xFF111111))),
-                  if (returnRate != null)
+                  Text('${_formatNumber(asset)}원',
+                      style: const TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w700,
+                          color: Color(0xFF111111))),
+                  if (returnRate != null) ...[
+                    const SizedBox(height: 2),
                     Text(
                       '${isPos ? '+' : ''}${returnRate.toStringAsFixed(2)}%',
-                      style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600,
-                        color: isPos ? const Color(0xFFE03131) : const Color(0xFF1971C2)),
+                      style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: isPos
+                              ? const Color(0xFFE03131)
+                              : const Color(0xFF1971C2)),
                     ),
+                  ],
                 ],
               ),
             ],
           ),
 
-          // triggeredCards 표시
+          // 시장 대비 배너
+          if (returnRate != null && spxReturnRate != null) ...[
+            const SizedBox(height: 6),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(
+                  horizontal: 10, vertical: 4),
+              decoration: BoxDecoration(
+                color: beatMarket
+                    ? const Color(0xFFE6F9F0)
+                    : const Color(0xFFFFF0F0),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                beatMarket
+                    ? '▲ 시장 대비 +${(returnRate - spxReturnRate).toStringAsFixed(1)}%p 우위'
+                    : '▼ 시장 대비 ${(returnRate - spxReturnRate).toStringAsFixed(1)}%p 뒤처짐',
+                style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: beatMarket
+                        ? const Color(0xFF0F6E56)
+                        : const Color(0xFFE03131)),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+
+          // 발동 카드
           if (round.triggeredCards.isNotEmpty) ...[
             const SizedBox(height: 8),
             Container(
               width: double.infinity,
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+              padding: const EdgeInsets.symmetric(
+                  horizontal: 10, vertical: 6),
               decoration: BoxDecoration(
                 color: const Color(0xFFEEEDFE),
                 borderRadius: BorderRadius.circular(8),
@@ -413,14 +612,11 @@ class _GameScreenState extends State<GameScreen> {
                 children: round.triggeredCards.map((id) {
                   final card = CardInfo.fromId(id);
                   if (card == null) return const SizedBox.shrink();
-                  return Text(
-                    '${card.emoji} ${card.name} 발동',
-                    style: const TextStyle(
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                      color: Color(0xFF3C3489),
-                    ),
-                  );
+                  return Text('${card.emoji} ${card.name} 발동',
+                      style: const TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                          color: Color(0xFF3C3489)));
                 }).toList(),
               ),
             ),
@@ -430,7 +626,7 @@ class _GameScreenState extends State<GameScreen> {
     );
   }
 
-  // ── 카드 선택 UI ────────────────────────────
+  // ── 카드 선택 UI ───────────────────────────
   Widget _buildCardSelector() {
     return Container(
       width: double.infinity,
@@ -443,16 +639,48 @@ class _GameScreenState extends State<GameScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('전략 카드를 선택하세요',
-            style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: Color(0xFF6B7684))),
-          const SizedBox(height: 10),
           Row(
-            children: _currentCardOptions.map((cardId) {
-              final card = CardInfo.fromId(cardId);
+            children: [
+              const Text('전략 카드를 선택하세요',
+                  style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: Color(0xFF6B7684))),
+              const Spacer(),
+              _buildAiButton(),
+            ],
+          ),
+
+          // 로딩 바
+          if (_aiState == AiState.loading) ...[
+            const SizedBox(height: 6),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: const LinearProgressIndicator(
+                backgroundColor: Color(0xFFEEEDFE),
+                valueColor:
+                    AlwaysStoppedAnimation(Color(0xFF534AB7)),
+                minHeight: 3,
+              ),
+            ),
+            const SizedBox(height: 3),
+            const Text('AI가 최적 카드를 분석 중입니다...',
+                style: TextStyle(
+                    fontSize: 9, color: Color(0xFF534AB7)),
+                textAlign: TextAlign.center),
+          ],
+
+          const SizedBox(height: 10),
+
+          Row(
+            children: _currentCardOptions.asMap().entries.map((e) {
+              final cardId = e.value;
+              final last   = e.key == _currentCardOptions.length - 1;
+              final card   = CardInfo.fromId(cardId);
               if (card == null) return const SizedBox.shrink();
               return Expanded(
                 child: Padding(
-                  padding: const EdgeInsets.only(right: 8),
+                  padding: EdgeInsets.only(right: last ? 0 : 8),
                   child: _buildCardItem(card),
                 ),
               );
@@ -463,56 +691,217 @@ class _GameScreenState extends State<GameScreen> {
     );
   }
 
+  // ── AI 버튼 ────────────────────────────────
+  Widget _buildAiButton() {
+    switch (_aiState) {
+      case AiState.idle:
+        return GestureDetector(
+          onTap: _requestAiRecommendation,
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+                horizontal: 10, vertical: 5),
+            decoration: BoxDecoration(
+              color: const Color(0xFF3C3489),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('✨', style: TextStyle(fontSize: 12)),
+                SizedBox(width: 4),
+                Text('AI 추천받기',
+                    style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.white)),
+              ],
+            ),
+          ),
+        );
+      case AiState.loading:
+        return Container(
+          padding: const EdgeInsets.symmetric(
+              horizontal: 10, vertical: 5),
+          decoration: BoxDecoration(
+            color: const Color(0xFF534AB7).withValues(alpha: 0.8),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                width: 10, height: 10,
+                child: CircularProgressIndicator(
+                    strokeWidth: 1.5,
+                    valueColor:
+                        AlwaysStoppedAnimation(Colors.white)),
+              ),
+              SizedBox(width: 6),
+              Text('분석 중...',
+                  style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.white)),
+            ],
+          ),
+        );
+      case AiState.done:
+        return Container(
+          padding: const EdgeInsets.symmetric(
+              horizontal: 10, vertical: 5),
+          decoration: BoxDecoration(
+            color: const Color(0xFF0F6E56),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('✅', style: TextStyle(fontSize: 12)),
+              SizedBox(width: 4),
+              Text('추천 완료',
+                  style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.white)),
+            ],
+          ),
+        );
+      case AiState.error:
+        return GestureDetector(
+          onTap: _requestAiRecommendation,
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+                horizontal: 10, vertical: 5),
+            decoration: BoxDecoration(
+              color: const Color(0xFFE03131),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text('⚠️', style: TextStyle(fontSize: 12)),
+                SizedBox(width: 4),
+                Text('다시 시도',
+                    style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.white)),
+              ],
+            ),
+          ),
+        );
+    }
+  }
+
+  // ── 카드 아이템 ────────────────────────────
   Widget _buildCardItem(CardInfo card) {
+    final aiPick       = _aiRecommendedCardId == card.id;
+    final contribution = _contributions[card.id];
+    final showContrib  =
+        _aiRequested && _aiState == AiState.done && contribution != null;
+
     return GestureDetector(
       onTap: _isSubmitting ? null : () => _onCardSelected(card.id),
-      child: Container(
-        padding: const EdgeInsets.all(12),
-        decoration: BoxDecoration(
-          color: const Color(0xFFEEEDFE),
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: const Color(0xFF534AB7), width: 1),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(card.emoji, style: const TextStyle(fontSize: 22)),
-            const SizedBox(height: 6),
-            Text(card.name,
-              style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w700, color: Color(0xFF3C3489))),
-            const SizedBox(height: 4),
-            Text(card.description,
-              style: const TextStyle(fontSize: 10, color: Color(0xFF534AB7), height: 1.4)),
-          ],
-        ),
+      child: Stack(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: aiPick
+                  ? const Color(0xFFDEDCFD)
+                  : const Color(0xFFEEEDFE),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: aiPick
+                    ? const Color(0xFF3C3489)
+                    : const Color(0xFF534AB7),
+                width: aiPick ? 2 : 1,
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(card.emoji,
+                    style: const TextStyle(fontSize: 22)),
+                const SizedBox(height: 6),
+                Text(card.name,
+                    style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                        color: Color(0xFF3C3489))),
+                const SizedBox(height: 4),
+                Text(card.description,
+                    style: const TextStyle(
+                        fontSize: 10,
+                        color: Color(0xFF534AB7),
+                        height: 1.4)),
+                // 기여도: 버튼 눌러서 완료됐을 때만
+                if (showContrib) ...[
+                  const SizedBox(height: 6),
+                  Text(
+                    '${contribution >= 0 ? '+' : ''}${contribution.toStringAsFixed(2)}%',
+                    style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                        color: contribution >= 0
+                            ? const Color(0xFF0F6E56)
+                            : const Color(0xFF993C1D)),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          // AI 추천 뱃지
+          if (aiPick)
+            Positioned(
+              top: 4, right: 4,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF3C3489),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Text('AI 추천',
+                    style: TextStyle(
+                        fontSize: 9,
+                        fontWeight: FontWeight.w700,
+                        color: Colors.white)),
+              ),
+            ),
+        ],
       ),
     );
   }
 
-  // ── 수동/자동 컨트롤 ────────────────────────
+  // ── 컨트롤 ────────────────────────────────
   Widget _buildControls() {
     return Row(
       children: [
-        // 자동 재생 토글
         GestureDetector(
           onTap: _isAutoPlaying ? _stopAutoPlay : _startAutoPlay,
           child: Container(
             width: 52, height: 52,
             decoration: BoxDecoration(
-              color: _isAutoPlaying ? const Color(0xFF3C3489) : Colors.white,
+              color: _isAutoPlaying
+                  ? const Color(0xFF3C3489)
+                  : Colors.white,
               borderRadius: BorderRadius.circular(14),
-              border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
+              border: Border.all(
+                  color: const Color(0xFFEEEEEE), width: 1),
             ),
             child: Icon(
-              _isAutoPlaying ? Icons.pause_rounded : Icons.play_arrow_rounded,
-              color: _isAutoPlaying ? Colors.white : const Color(0xFF111111),
+              _isAutoPlaying
+                  ? Icons.pause_rounded
+                  : Icons.play_arrow_rounded,
+              color: _isAutoPlaying
+                  ? Colors.white
+                  : const Color(0xFF111111),
               size: 24,
             ),
           ),
         ),
         const SizedBox(width: 10),
-
-        // 다음 라운드 / 게임 종료 버튼
         Expanded(
           child: SizedBox(
             height: 52,
@@ -528,13 +917,15 @@ class _GameScreenState extends State<GameScreen> {
                     : const Color(0xFF111111),
                 foregroundColor: Colors.white,
                 elevation: 0,
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14)),
               ),
               child: Text(
                 _isLastRound
                     ? '결과 보기'
                     : '다음 라운드 ($_currentRound1 / ${_session.totalRounds})',
-                style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w700),
+                style: const TextStyle(
+                    fontSize: 14, fontWeight: FontWeight.w700),
               ),
             ),
           ),
@@ -543,10 +934,25 @@ class _GameScreenState extends State<GameScreen> {
     );
   }
 
+  // ── 유틸 ──────────────────────────────────
+  Color _tickerColor(String ticker) {
+    const colors = {
+      '^SPX': Color(0xFF1971C2),
+      '^NDX': Color(0xFF7048E8),
+      'GLD':  Color(0xFFE67700),
+      'USO':  Color(0xFF2F9E44),
+      'AAPL': Color(0xFF868E96),
+      'TLT':  Color(0xFFE64980),
+    };
+    return colors[ticker] ?? const Color(0xFF6B7684);
+  }
+
   String _formatNumber(double value) {
-    return value.toStringAsFixed(0).replaceAllMapped(
-      RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
-      (m) => '${m[1]},',
-    );
+    return value
+        .toStringAsFixed(0)
+        .replaceAllMapped(
+          RegExp(r'(\d{1,3})(?=(\d{3})+(?!\d))'),
+          (m) => '${m[1]},',
+        );
   }
 }

--- a/frontEnd/lib/services/api_client.dart
+++ b/frontEnd/lib/services/api_client.dart
@@ -3,7 +3,7 @@ import 'package:dio/dio.dart';
 class ApiClient {
   //static const String _baseUrl = 'http://172.22.165.231:8080';
   //static const String _baseUrl = 'http://172.18.16.192:8080';
-  static const String _baseUrl = 'http://172.18.35.92:8080';
+  static const String _baseUrl = 'http://172.18.48.102:8080';
   
 
   final Dio _dio = Dio(BaseOptions(

--- a/frontEnd/lib/services/game_service.dart
+++ b/frontEnd/lib/services/game_service.dart
@@ -1,19 +1,21 @@
 import '../models/scenario.dart';
 import '../models/game_session.dart';
 import '../models/action_result.dart';
+import '../models/v1_recommend_result.dart';
+import '../models/v2_recommend_result.dart';
 import 'api_client.dart';
 
 class GameService {
   final ApiClient _client = ApiClient();
 
-  // GET /game/scenarios
+  // ── GET /game/scenarios ─────────────────────
   Future<List<Scenario>> getScenarios() async {
     final data = await _client.get('/game/scenarios');
     final List<dynamic> list = data as List<dynamic>;
     return list.map((json) => Scenario.fromJson(json)).toList();
   }
 
-  // POST /game/start
+  // ── POST /game/start ────────────────────────
   Future<GameSession> startGame(int scenarioId) async {
     final data = await _client.post(
       '/game/start',
@@ -22,8 +24,7 @@ class GameService {
     return GameSession.fromJson(data as Map<String, dynamic>);
   }
 
-  // POST /game/round/action
-  // 카드 선택 → 해당 라운드 ~ 다음 증강 직전까지 계산된 결과 받기
+  // ── POST /game/round/action ─────────────────
   Future<ActionResult> submitAction({
     required String sessionId,
     required int round,
@@ -38,5 +39,41 @@ class GameService {
       },
     );
     return ActionResult.fromJson(data as Map<String, dynamic>);
+  }
+
+  // ── POST /game/recommend/v1 ─────────────────
+  // V1.5 사전 추천: 게임 시작 후 백그라운드 호출
+  // 전체 100라운드 SPX 기준, 4개 라운드 추천
+  // 응답 시간: 약 1~2분 (7,920개 순열 계산)
+  Future<V1RecommendResult> getV1Recommendation({
+    required String sessionId,
+  }) async {
+    final data = await _client.post(
+      '/game/recommend/v1',
+      body: {'sessionId': sessionId},
+    );
+    return V1RecommendResult.fromJson(data as Map<String, dynamic>);
+  }
+
+  // ── POST /game/recommend/v2 ─────────────────
+  // V2 실시간 추천: 25·50라운드 카드 선택 시
+  // so_far 시장 지표 + 이미 선택한 카드 기반
+  // 75라운드 제외 (스피어만 역상관 ρ=-0.12)
+  Future<V2RecommendResult> getV2Recommendation({
+    required String sessionId,
+    required int currentRound,
+    required List<int> alreadyCards,
+    required List<int> candidateCards,
+  }) async {
+    final data = await _client.post(
+      '/game/recommend/v2',
+      body: {
+        'sessionId':      sessionId,
+        'currentRound':   currentRound,
+        'alreadyCards':   alreadyCards,
+        'candidateCards': candidateCards,
+      },
+    );
+    return V2RecommendResult.fromJson(data as Map<String, dynamic>);
   }
 }

--- a/frontEnd/lib/widgets/holdings_widget.dart
+++ b/frontEnd/lib/widgets/holdings_widget.dart
@@ -1,0 +1,373 @@
+import 'package:flutter/material.dart';
+import '../models/card_info.dart';
+import '../models/round_data.dart';
+
+// =============================================
+// 보유 종목 데이터
+// =============================================
+class HoldingInfo {
+  final String ticker;
+  final String cardName;
+  final String emoji;
+  final double currentChangeRate;
+  final List<double> recentChanges; // 스파크라인용 등락률 히스토리
+  final bool isNew;                 // 이번 라운드 새로 추가됐는지
+
+  HoldingInfo({
+    required this.ticker,
+    required this.cardName,
+    required this.emoji,
+    required this.currentChangeRate,
+    required this.recentChanges,
+    this.isNew = false,
+  });
+}
+
+// =============================================
+// 선택된 카드 목록에서 보유 종목 추출
+// =============================================
+List<HoldingInfo> extractHoldings({
+  required List<int> selectedCardIds,
+  required List<RoundData> rounds,
+  required int currentRoundIndex,
+  int? newCardId, // 이번 라운드 새로 선택한 카드
+}) {
+  final holdings  = <HoldingInfo>[];
+  final seenTickers = <String>{};
+
+  // SPX는 기준 지수 → 보유 종목에서 제외
+  const exclude = {'^SPX'};
+
+  for (final cardId in selectedCardIds) {
+    final card = CardInfo.fromId(cardId);
+    if (card == null) continue;
+    if (exclude.contains(card.ticker)) continue;
+    if (seenTickers.contains(card.ticker)) continue;
+    seenTickers.add(card.ticker);
+
+    // 현재 등락률
+    final currentRound = currentRoundIndex < rounds.length
+        ? rounds[currentRoundIndex]
+        : null;
+    final changeRate = currentRound?.getPrice(card.ticker)?.changeRate ?? 0.0;
+
+    // 최근 20라운드 등락률 히스토리
+    final history = <double>[];
+    final start = (currentRoundIndex - 19).clamp(0, rounds.length - 1);
+    for (int i = start; i <= currentRoundIndex && i < rounds.length; i++) {
+      final p = rounds[i].getPrice(card.ticker);
+      if (p != null) history.add(p.changeRate);
+    }
+
+    holdings.add(HoldingInfo(
+      ticker:            card.ticker,
+      cardName:          card.name,
+      emoji:             card.emoji,
+      currentChangeRate: changeRate,
+      recentChanges:     history,
+      isNew:             cardId == newCardId,
+    ));
+  }
+
+  return holdings;
+}
+
+// =============================================
+// 스파크라인 페인터
+// =============================================
+class _SparklinePainter extends CustomPainter {
+  final List<double> values;
+  final Color color;
+
+  _SparklinePainter({required this.values, required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (values.length < 2) return;
+    final min = values.reduce((a, b) => a < b ? a : b);
+    final max = values.reduce((a, b) => a > b ? a : b);
+    final range = (max - min).abs();
+
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = 1.5
+      ..strokeCap = StrokeCap.round
+      ..style = PaintingStyle.stroke;
+
+    final path = Path();
+    for (int i = 0; i < values.length; i++) {
+      final x = i / (values.length - 1) * size.width;
+      final normalized = range < 0.001 ? 0.5 : (values[i] - min) / range;
+      // 위아래 10% 여백
+      final y = size.height - normalized * size.height * 0.8 - size.height * 0.1;
+      if (i == 0) {
+        path.moveTo(x, y);
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(_SparklinePainter old) =>
+      old.values != values || old.color != color;
+}
+
+// =============================================
+// 게임 진행 중 보유종목 위젯 (스파크라인)
+// 1~3개: 기본 크기, 4개: 이름 숨기고 축소
+// =============================================
+class HoldingsGameWidget extends StatelessWidget {
+  final List<HoldingInfo> holdings;
+
+  const HoldingsGameWidget({super.key, required this.holdings});
+
+  @override
+  Widget build(BuildContext context) {
+    if (holdings.isEmpty) return const SizedBox.shrink();
+
+    final compact = holdings.length == 4;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '보유 종목 (${holdings.length})',
+            style: const TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: Color(0xFF6B7684),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: holdings.asMap().entries.map((entry) {
+              final i    = entry.key;
+              final h    = entry.value;
+              final last = i == holdings.length - 1;
+              return Expanded(
+                child: Padding(
+                  padding: EdgeInsets.only(right: last ? 0 : 6),
+                  child: _SparkCard(holding: h, compact: compact),
+                ),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SparkCard extends StatelessWidget {
+  final HoldingInfo holding;
+  final bool compact;
+
+  const _SparkCard({required this.holding, this.compact = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final isPos  = holding.currentChangeRate >= 0;
+    final color  = isPos ? const Color(0xFFE03131) : const Color(0xFF1971C2);
+
+    return Container(
+      padding: EdgeInsets.all(compact ? 5 : 7),
+      decoration: BoxDecoration(
+        color: holding.isNew
+            ? const Color(0xFFF8F7FF)
+            : const Color(0xFFF8F9FA),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+          color: holding.isNew
+              ? const Color(0xFF534AB7)
+              : const Color(0xFFEEEEEE),
+          width: holding.isNew ? 1.0 : 0.5,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 티커
+          Text(
+            holding.ticker.replaceAll('^', ''),
+            style: TextStyle(
+              fontSize: compact ? 9 : 10,
+              fontWeight: FontWeight.w600,
+              color: holding.isNew
+                  ? const Color(0xFF534AB7)
+                  : const Color(0xFF111111),
+            ),
+            overflow: TextOverflow.ellipsis,
+          ),
+
+          // 이름: 1~3개일 때만
+          if (!compact) ...[
+            const SizedBox(height: 1),
+            Text(
+              holding.cardName,
+              style: const TextStyle(fontSize: 8, color: Color(0xFF6B7684)),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+
+          // 스파크라인
+          const SizedBox(height: 4),
+          SizedBox(
+            height: compact ? 14 : 18,
+            child: holding.recentChanges.length >= 2
+                ? CustomPaint(
+                    painter: _SparklinePainter(
+                      values: holding.recentChanges,
+                      color: color,
+                    ),
+                    size: Size.infinite,
+                  )
+                : const SizedBox.shrink(),
+          ),
+
+          // 등락률
+          const SizedBox(height: 2),
+          Text(
+            '${isPos ? '+' : ''}${holding.currentChangeRate.toStringAsFixed(1)}%',
+            style: TextStyle(
+              fontSize: compact ? 7 : 8,
+              fontWeight: FontWeight.w600,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// =============================================
+// 카드 선택 라운드 보유종목 위젯 (2×2 그리드)
+// 차트 없음, 빈 슬롯 표시, 4칸 고정
+// =============================================
+class HoldingsMiniGrid extends StatelessWidget {
+  final List<HoldingInfo> holdings;
+
+  const HoldingsMiniGrid({super.key, required this.holdings});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '보유 종목 (${holdings.length})',
+            style: const TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: Color(0xFF6B7684),
+            ),
+          ),
+          const SizedBox(height: 8),
+          GridView.count(
+            crossAxisCount: 2,
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            crossAxisSpacing: 6,
+            mainAxisSpacing: 6,
+            childAspectRatio: 3.8,
+            children: [
+              ...holdings.map((h) => _MiniCard(holding: h)),
+              // 빈 슬롯 채우기 (총 4칸)
+              ...List.generate(
+                (4 - holdings.length).clamp(0, 4),
+                (_) => const _EmptySlot(),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MiniCard extends StatelessWidget {
+  final HoldingInfo holding;
+
+  const _MiniCard({required this.holding});
+
+  @override
+  Widget build(BuildContext context) {
+    final isPos = holding.currentChangeRate >= 0;
+    final color = isPos ? const Color(0xFFE03131) : const Color(0xFF1971C2);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+      decoration: BoxDecoration(
+        color: holding.isNew
+            ? const Color(0xFFF8F7FF)
+            : const Color(0xFFF8F9FA),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: holding.isNew
+              ? const Color(0xFF534AB7)
+              : const Color(0xFFEEEEEE),
+          width: holding.isNew ? 1.0 : 0.5,
+        ),
+      ),
+      child: Row(
+        children: [
+          Text(holding.emoji, style: const TextStyle(fontSize: 12)),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              holding.ticker.replaceAll('^', ''),
+              style: TextStyle(
+                fontSize: 9,
+                fontWeight: FontWeight.w600,
+                color: holding.isNew
+                    ? const Color(0xFF534AB7)
+                    : const Color(0xFF111111),
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          Text(
+            '${isPos ? '+' : ''}${holding.currentChangeRate.toStringAsFixed(1)}%',
+            style: TextStyle(
+                fontSize: 9, fontWeight: FontWeight.w600, color: color),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptySlot extends StatelessWidget {
+  const _EmptySlot();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: const Color(0xFFEEEEEE),
+          width: 0.5,
+        ),
+      ),
+    );
+  }
+}

--- a/frontEnd/lib/widgets/holdings_widget.dart
+++ b/frontEnd/lib/widgets/holdings_widget.dart
@@ -3,68 +3,52 @@ import '../models/card_info.dart';
 import '../models/round_data.dart';
 
 // =============================================
-// 보유 종목 데이터
+// 보유 카드 데이터
 // =============================================
-class HoldingInfo {
+class HoldingCardInfo {
+  final int cardId;
   final String ticker;
   final String cardName;
   final String emoji;
   final double currentChangeRate;
-  final List<double> recentChanges; // 스파크라인용 등락률 히스토리
-  final bool isNew;                 // 이번 라운드 새로 추가됐는지
+  final bool isNew;
 
-  HoldingInfo({
+  HoldingCardInfo({
+    required this.cardId,
     required this.ticker,
     required this.cardName,
     required this.emoji,
     required this.currentChangeRate,
-    required this.recentChanges,
     this.isNew = false,
   });
 }
 
-// =============================================
-// 선택된 카드 목록에서 보유 종목 추출
-// =============================================
-List<HoldingInfo> extractHoldings({
+// 선택된 카드 목록에서 보유 카드 추출
+// ^SPX 포함, 선택한 카드 기준 (중복 티커도 각각 슬롯)
+List<HoldingCardInfo> extractHoldingCards({
   required List<int> selectedCardIds,
   required List<RoundData> rounds,
   required int currentRoundIndex,
-  int? newCardId, // 이번 라운드 새로 선택한 카드
+  int? newCardId,
 }) {
-  final holdings  = <HoldingInfo>[];
-  final seenTickers = <String>{};
-
-  // SPX는 기준 지수 → 보유 종목에서 제외
-  const exclude = {'^SPX'};
+  final holdings = <HoldingCardInfo>[];
 
   for (final cardId in selectedCardIds) {
     final card = CardInfo.fromId(cardId);
     if (card == null) continue;
-    if (exclude.contains(card.ticker)) continue;
-    if (seenTickers.contains(card.ticker)) continue;
-    seenTickers.add(card.ticker);
 
-    // 현재 등락률
     final currentRound = currentRoundIndex < rounds.length
         ? rounds[currentRoundIndex]
         : null;
-    final changeRate = currentRound?.getPrice(card.ticker)?.changeRate ?? 0.0;
+    final changeRate =
+        currentRound?.getPrice(card.ticker)?.changeRate ?? 0.0;
 
-    // 최근 20라운드 등락률 히스토리
-    final history = <double>[];
-    final start = (currentRoundIndex - 19).clamp(0, rounds.length - 1);
-    for (int i = start; i <= currentRoundIndex && i < rounds.length; i++) {
-      final p = rounds[i].getPrice(card.ticker);
-      if (p != null) history.add(p.changeRate);
-    }
-
-    holdings.add(HoldingInfo(
+    holdings.add(HoldingCardInfo(
+      cardId:            cardId,
       ticker:            card.ticker,
       cardName:          card.name,
       emoji:             card.emoji,
       currentChangeRate: changeRate,
-      recentChanges:     history,
       isNew:             cardId == newCardId,
     ));
   }
@@ -73,61 +57,22 @@ List<HoldingInfo> extractHoldings({
 }
 
 // =============================================
-// 스파크라인 페인터
+// 보유 카드 위젯 (게임 진행 중 / 카드 선택 모두 동일)
+// 2x2 공간 고정, 빈 슬롯 없음, 발동 애니메이션
 // =============================================
-class _SparklinePainter extends CustomPainter {
-  final List<double> values;
-  final Color color;
+class HoldingCardsWidget extends StatelessWidget {
+  final List<HoldingCardInfo> cards;
+  final List<int> triggeredCardIds; // 이번 라운드 발동한 카드
 
-  _SparklinePainter({required this.values, required this.color});
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    if (values.length < 2) return;
-    final min = values.reduce((a, b) => a < b ? a : b);
-    final max = values.reduce((a, b) => a > b ? a : b);
-    final range = (max - min).abs();
-
-    final paint = Paint()
-      ..color = color
-      ..strokeWidth = 1.5
-      ..strokeCap = StrokeCap.round
-      ..style = PaintingStyle.stroke;
-
-    final path = Path();
-    for (int i = 0; i < values.length; i++) {
-      final x = i / (values.length - 1) * size.width;
-      final normalized = range < 0.001 ? 0.5 : (values[i] - min) / range;
-      // 위아래 10% 여백
-      final y = size.height - normalized * size.height * 0.8 - size.height * 0.1;
-      if (i == 0) {
-        path.moveTo(x, y);
-      } else {
-        path.lineTo(x, y);
-      }
-    }
-    canvas.drawPath(path, paint);
-  }
-
-  @override
-  bool shouldRepaint(_SparklinePainter old) =>
-      old.values != values || old.color != color;
-}
-
-// =============================================
-// 게임 진행 중 보유종목 위젯 (스파크라인)
-// 1~3개: 기본 크기, 4개: 이름 숨기고 축소
-// =============================================
-class HoldingsGameWidget extends StatelessWidget {
-  final List<HoldingInfo> holdings;
-
-  const HoldingsGameWidget({super.key, required this.holdings});
+  const HoldingCardsWidget({
+    super.key,
+    required this.cards,
+    this.triggeredCardIds = const [],
+  });
 
   @override
   Widget build(BuildContext context) {
-    if (holdings.isEmpty) return const SizedBox.shrink();
-
-    final compact = holdings.length == 4;
+    if (cards.isEmpty) return const SizedBox.shrink();
 
     return Container(
       width: double.infinity,
@@ -140,233 +85,194 @@ class HoldingsGameWidget extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            '보유 종목 (${holdings.length})',
-            style: const TextStyle(
+          const Text(
+            '보유 카드',
+            style: TextStyle(
               fontSize: 11,
               fontWeight: FontWeight.w600,
               color: Color(0xFF6B7684),
             ),
           ),
           const SizedBox(height: 8),
-          Row(
-            children: holdings.asMap().entries.map((entry) {
-              final i    = entry.key;
-              final h    = entry.value;
-              final last = i == holdings.length - 1;
-              return Expanded(
-                child: Padding(
-                  padding: EdgeInsets.only(right: last ? 0 : 6),
-                  child: _SparkCard(holding: h, compact: compact),
-                ),
-              );
-            }).toList(),
-          ),
+          // 2x2 공간 고정: GridView 대신 직접 레이아웃
+          _buildGrid(),
         ],
       ),
     );
   }
+
+  Widget _buildGrid() {
+    // 최대 4개, 2열 고정
+    // 공간은 항상 2x2 기준으로 확보
+    // 슬롯은 있는 것만 (빈 위젯 없음)
+    final rows = <Widget>[];
+
+    for (int i = 0; i < cards.length; i += 2) {
+      final left  = cards[i];
+      final right = i + 1 < cards.length ? cards[i + 1] : null;
+
+      rows.add(
+        Padding(
+          padding: EdgeInsets.only(bottom: i + 2 < cards.length ? 6 : 0),
+          child: Row(
+            children: [
+              Expanded(
+                child: _HoldingCardSlot(
+                  card:        left,
+                  isTriggered: triggeredCardIds.contains(left.cardId),
+                ),
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: right != null
+                    ? _HoldingCardSlot(
+                        card:        right,
+                        isTriggered: triggeredCardIds.contains(right.cardId),
+                      )
+                    // 오른쪽 슬롯 없을 때: 공간만 차지 (투명)
+                    : const SizedBox.shrink(),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Column(children: rows);
+  }
 }
 
-class _SparkCard extends StatelessWidget {
-  final HoldingInfo holding;
-  final bool compact;
+// =============================================
+// 개별 슬롯 (발동 애니메이션 포함)
+// =============================================
+class _HoldingCardSlot extends StatefulWidget {
+  final HoldingCardInfo card;
+  final bool isTriggered;
 
-  const _SparkCard({required this.holding, this.compact = false});
+  const _HoldingCardSlot({
+    required this.card,
+    this.isTriggered = false,
+  });
+
+  @override
+  State<_HoldingCardSlot> createState() => _HoldingCardSlotState();
+}
+
+class _HoldingCardSlotState extends State<_HoldingCardSlot>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _scaleAnim;
+  late Animation<double> _borderAnim;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    );
+
+    // 스케일: 1.0 → 1.08 → 1.0
+    _scaleAnim = TweenSequence([
+      TweenSequenceItem(
+          tween: Tween(begin: 1.0, end: 1.08)
+              .chain(CurveTween(curve: Curves.easeOut)),
+          weight: 40),
+      TweenSequenceItem(
+          tween: Tween(begin: 1.08, end: 1.0)
+              .chain(CurveTween(curve: Curves.elasticOut)),
+          weight: 60),
+    ]).animate(_controller);
+
+    // 아웃라인 투명도: 0 → 1 → 0
+    _borderAnim = TweenSequence([
+      TweenSequenceItem(
+          tween: Tween(begin: 0.0, end: 1.0)
+              .chain(CurveTween(curve: Curves.easeOut)),
+          weight: 30),
+      TweenSequenceItem(
+          tween: Tween(begin: 1.0, end: 0.0)
+              .chain(CurveTween(curve: Curves.easeIn)),
+          weight: 70),
+    ]).animate(_controller);
+
+    if (widget.isTriggered) {
+      _controller.forward();
+    }
+  }
+
+  @override
+  void didUpdateWidget(_HoldingCardSlot old) {
+    super.didUpdateWidget(old);
+    // 새로 발동됐을 때 애니메이션 재실행
+    if (widget.isTriggered && !old.isTriggered) {
+      _controller.forward(from: 0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final isPos  = holding.currentChangeRate >= 0;
+    final isPos  = widget.card.currentChangeRate >= 0;
     final color  = isPos ? const Color(0xFFE03131) : const Color(0xFF1971C2);
 
-    return Container(
-      padding: EdgeInsets.all(compact ? 5 : 7),
-      decoration: BoxDecoration(
-        color: holding.isNew
-            ? const Color(0xFFF8F7FF)
-            : const Color(0xFFF8F9FA),
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(
-          color: holding.isNew
-              ? const Color(0xFF534AB7)
-              : const Color(0xFFEEEEEE),
-          width: holding.isNew ? 1.0 : 0.5,
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return Transform.scale(
+          scale: _scaleAnim.value,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 7),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF8F9FA),
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(
+                color: widget.isTriggered
+                    ? const Color(0xFFFFB800)
+                        .withValues(alpha: _borderAnim.value)
+                    : const Color(0xFFEEEEEE),
+                width: widget.isTriggered ? 2 : 0.5,
+              ),
+            ),
+            child: child,
+          ),
+        );
+      },
+      child: Row(
         children: [
-          // 티커
-          Text(
-            holding.ticker.replaceAll('^', ''),
-            style: TextStyle(
-              fontSize: compact ? 9 : 10,
-              fontWeight: FontWeight.w600,
-              color: holding.isNew
-                  ? const Color(0xFF534AB7)
-                  : const Color(0xFF111111),
+          Text(widget.card.emoji,
+              style: const TextStyle(fontSize: 14)),
+          const SizedBox(width: 5),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  widget.card.ticker.replaceAll('^', ''),
+                  style: const TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF111111),
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
             ),
-            overflow: TextOverflow.ellipsis,
           ),
-
-          // 이름: 1~3개일 때만
-          if (!compact) ...[
-            const SizedBox(height: 1),
-            Text(
-              holding.cardName,
-              style: const TextStyle(fontSize: 8, color: Color(0xFF6B7684)),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
-
-          // 스파크라인
-          const SizedBox(height: 4),
-          SizedBox(
-            height: compact ? 14 : 18,
-            child: holding.recentChanges.length >= 2
-                ? CustomPaint(
-                    painter: _SparklinePainter(
-                      values: holding.recentChanges,
-                      color: color,
-                    ),
-                    size: Size.infinite,
-                  )
-                : const SizedBox.shrink(),
-          ),
-
-          // 등락률
-          const SizedBox(height: 2),
           Text(
-            '${isPos ? '+' : ''}${holding.currentChangeRate.toStringAsFixed(1)}%',
+            '${isPos ? '+' : ''}${widget.card.currentChangeRate.toStringAsFixed(1)}%',
             style: TextStyle(
-              fontSize: compact ? 7 : 8,
+              fontSize: 10,
               fontWeight: FontWeight.w600,
               color: color,
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-// =============================================
-// 카드 선택 라운드 보유종목 위젯 (2×2 그리드)
-// 차트 없음, 빈 슬롯 표시, 4칸 고정
-// =============================================
-class HoldingsMiniGrid extends StatelessWidget {
-  final List<HoldingInfo> holdings;
-
-  const HoldingsMiniGrid({super.key, required this.holdings});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: const Color(0xFFEEEEEE), width: 1),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            '보유 종목 (${holdings.length})',
-            style: const TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-              color: Color(0xFF6B7684),
-            ),
-          ),
-          const SizedBox(height: 8),
-          GridView.count(
-            crossAxisCount: 2,
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            crossAxisSpacing: 6,
-            mainAxisSpacing: 6,
-            childAspectRatio: 3.8,
-            children: [
-              ...holdings.map((h) => _MiniCard(holding: h)),
-              // 빈 슬롯 채우기 (총 4칸)
-              ...List.generate(
-                (4 - holdings.length).clamp(0, 4),
-                (_) => const _EmptySlot(),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _MiniCard extends StatelessWidget {
-  final HoldingInfo holding;
-
-  const _MiniCard({required this.holding});
-
-  @override
-  Widget build(BuildContext context) {
-    final isPos = holding.currentChangeRate >= 0;
-    final color = isPos ? const Color(0xFFE03131) : const Color(0xFF1971C2);
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
-      decoration: BoxDecoration(
-        color: holding.isNew
-            ? const Color(0xFFF8F7FF)
-            : const Color(0xFFF8F9FA),
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: holding.isNew
-              ? const Color(0xFF534AB7)
-              : const Color(0xFFEEEEEE),
-          width: holding.isNew ? 1.0 : 0.5,
-        ),
-      ),
-      child: Row(
-        children: [
-          Text(holding.emoji, style: const TextStyle(fontSize: 12)),
-          const SizedBox(width: 4),
-          Expanded(
-            child: Text(
-              holding.ticker.replaceAll('^', ''),
-              style: TextStyle(
-                fontSize: 9,
-                fontWeight: FontWeight.w600,
-                color: holding.isNew
-                    ? const Color(0xFF534AB7)
-                    : const Color(0xFF111111),
-              ),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-          Text(
-            '${isPos ? '+' : ''}${holding.currentChangeRate.toStringAsFixed(1)}%',
-            style: TextStyle(
-                fontSize: 9, fontWeight: FontWeight.w600, color: color),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _EmptySlot extends StatelessWidget {
-  const _EmptySlot();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: const Color(0xFFEEEEEE),
-          width: 0.5,
-        ),
       ),
     );
   }

--- a/frontEnd/lib/widgets/stock_chart.dart
+++ b/frontEnd/lib/widgets/stock_chart.dart
@@ -1,159 +1,113 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import '../models/round_data.dart';
-import '../models/price_data.dart';
-
-// 종목별 고정 색상
-const Map<String, Color> tickerColors = {
-  '^SPX':  Color(0xFF1971C2),  // 파랑
-  '^NDX':  Color(0xFF7048E8),  // 보라
-  'GLD':   Color(0xFFE67700),  // 주황
-  'USO':   Color(0xFF2F9E44),  // 초록
-  'AAPL':  Color(0xFF868E96),  // 회색
-  'TLT':   Color(0xFFE64980),  // 분홍
-};
-
-// 10배 배율이 필요한 종목 목록
-// ^SPX, ^NDX는 1200~1700 범위라 배율 불필요
-// 나머지는 100 이하라 10배 적용
-const Set<String> _scaledTickers = {'GLD', 'USO', 'AAPL', 'TLT'};
-
-Color tickerColor(String ticker) =>
-    tickerColors[ticker] ?? const Color(0xFF6B7684);
-
-double _applyScale(String ticker, double value) =>
-    _scaledTickers.contains(ticker) ? value * 10 : value;
 
 class StockChart extends StatelessWidget {
   final List<RoundData> rounds;
+  final double initialAsset;
 
   const StockChart({
     super.key,
     required this.rounds,
+    this.initialAsset = 10000000,
   });
 
-  // rounds에 존재하는 ticker 목록 추출
-  List<String> get _tickers {
-    if (rounds.isEmpty) return [];
-    final Set<String> seen = {};
-    final List<String> result = [];
+  // SPX 첫날 종가 (정규화 기준점)
+  double? get _spxBase {
     for (final r in rounds) {
-      for (final p in r.priceData) {
-        if (seen.add(p.ticker)) result.add(p.ticker);
-      }
+      final p = r.getPrice('^SPX');
+      if (p != null && p.close > 0) return p.close;
     }
-    return result;
+    return null;
   }
 
-  // 특정 ticker의 FlSpot 리스트 (배율 적용)
-  List<FlSpot> _spots(String ticker) {
-    final List<FlSpot> spots = [];
+  // S&P500 수익률(%) FlSpot 리스트
+  List<FlSpot> get _spxSpots {
+    final base = _spxBase;
+    if (base == null) return [];
+    final spots = <FlSpot>[];
     for (int i = 0; i < rounds.length; i++) {
-      final price = rounds[i].getPrice(ticker);
-      if (price != null) {
-        spots.add(FlSpot(i.toDouble(), _applyScale(ticker, price.close)));
+      final p = rounds[i].getPrice('^SPX');
+      if (p != null) {
+        final pct = (p.close - base) / base * 100;
+        spots.add(FlSpot(i.toDouble(), pct));
       }
     }
     return spots;
   }
 
-  // roundAsset 기반 내 자산 FlSpot 리스트
+  // 내 자산 수익률(%) FlSpot 리스트
   List<FlSpot> get _assetSpots {
-    final List<FlSpot> spots = [];
+    final spots = <FlSpot>[];
     for (int i = 0; i < rounds.length; i++) {
       final asset = rounds[i].roundAsset;
       if (asset != null) {
-        // 자산을 종목 스케일(~1200)에 맞게 축소: 10,000,000 → 1000 수준
-        spots.add(FlSpot(i.toDouble(), asset / 10000));
+        final pct = (asset - initialAsset) / initialAsset * 100;
+        spots.add(FlSpot(i.toDouble(), pct));
       }
     }
     return spots;
   }
 
-  // Y축 범위 (배율 적용된 종목 가격 + 자산 스팟 모두 포함)
   double get _minY {
-    double min = double.infinity;
-    for (final ticker in _tickers) {
-      for (final r in rounds) {
-        final price = r.getPrice(ticker);
-        if (price != null) {
-          final v = _applyScale(ticker, price.close);
-          if (v < min) min = v;
-        }
-      }
+    double min = 0;
+    for (final s in [..._spxSpots, ..._assetSpots]) {
+      if (s.y < min) min = s.y;
     }
-    for (final r in rounds) {
-      final asset = r.roundAsset;
-      if (asset != null) {
-        final v = asset / 10000;
-        if (v < min) min = v;
-      }
-    }
-    return min == double.infinity ? 0 : min * 0.97;
+    // 여유분 10% + 최소 -2%
+    return ((min * 1.15) - 2).floorToDouble();
   }
 
   double get _maxY {
-    double max = double.negativeInfinity;
-    for (final ticker in _tickers) {
-      for (final r in rounds) {
-        final price = r.getPrice(ticker);
-        if (price != null) {
-          final v = _applyScale(ticker, price.close);
-          if (v > max) max = v;
-        }
-      }
+    double max = 0;
+    for (final s in [..._spxSpots, ..._assetSpots]) {
+      if (s.y > max) max = s.y;
     }
-    for (final r in rounds) {
-      final asset = r.roundAsset;
-      if (asset != null) {
-        final v = asset / 10000;
-        if (v > max) max = v;
-      }
-    }
-    return max == double.negativeInfinity ? 100 : max * 1.03;
+    return ((max * 1.15) + 2).ceilToDouble();
   }
 
   @override
   Widget build(BuildContext context) {
     if (rounds.isEmpty) {
       return const Center(
-        child: Text('데이터 없음', style: TextStyle(color: Color(0xFF6B7684))),
+        child: Text('데이터 없음',
+            style: TextStyle(color: Color(0xFF6B7684))),
       );
     }
 
-    final tickers = _tickers;
+    final spxSpots   = _spxSpots;
     final assetSpots = _assetSpots;
-    final hasAsset = assetSpots.isNotEmpty;
+    final hasAsset   = assetSpots.isNotEmpty;
+    final minY       = _minY;
+    final maxY       = _maxY;
+    final range      = (maxY - minY).abs();
+    final interval   = range > 0 ? (range / 4) : 2.0;
 
-    // 종목 선 + 자산 선 합치기
-    final List<LineChartBarData> lineBars = [
-      // 종목별 선
-      ...tickers.map((ticker) {
-        final spots = _spots(ticker);
-        final color = tickerColor(ticker);
-        return LineChartBarData(
-          spots: spots,
-          color: color,
+    final lineBars = <LineChartBarData>[
+      // S&P 500 (파랑)
+      if (spxSpots.isNotEmpty)
+        LineChartBarData(
+          spots: spxSpots,
+          color: const Color(0xFF1971C2),
           barWidth: 1.5,
           isCurved: true,
           curveSmoothness: 0.3,
           dotData: FlDotData(
             show: true,
-            getDotPainter: (spot, _, __, index) {
-              final isLastDot = index == spots.length - 1;
+            getDotPainter: (spot, _, __, idx) {
+              final last = idx == spxSpots.length - 1;
               return FlDotCirclePainter(
-                radius: isLastDot ? 3 : 0,
-                color: color,
-                strokeWidth: isLastDot ? 2 : 0,
+                radius: last ? 3 : 0,
+                color: const Color(0xFF1971C2),
+                strokeWidth: last ? 2 : 0,
                 strokeColor: Colors.white,
               );
             },
           ),
           belowBarData: BarAreaData(show: false),
-        );
-      }),
+        ),
 
-      // 내 자산 선 (흰색 굵은 선)
+      // 내 자산 (검정)
       if (hasAsset)
         LineChartBarData(
           spots: assetSpots,
@@ -163,19 +117,19 @@ class StockChart extends StatelessWidget {
           curveSmoothness: 0.3,
           dotData: FlDotData(
             show: true,
-            getDotPainter: (spot, _, __, index) {
-              final isLastDot = index == assetSpots.length - 1;
+            getDotPainter: (spot, _, __, idx) {
+              final last = idx == assetSpots.length - 1;
               return FlDotCirclePainter(
-                radius: isLastDot ? 4 : 0,
+                radius: last ? 4 : 0,
                 color: const Color(0xFF111111),
-                strokeWidth: isLastDot ? 2 : 0,
+                strokeWidth: last ? 2 : 0,
                 strokeColor: Colors.white,
               );
             },
           ),
           belowBarData: BarAreaData(
             show: true,
-            color: const Color(0xFF111111).withValues(alpha: 0.05),
+            color: const Color(0xFF111111).withValues(alpha: 0.04),
           ),
         ),
     ];
@@ -184,31 +138,13 @@ class StockChart extends StatelessWidget {
       children: [
         // 범례
         Padding(
-          padding: const EdgeInsets.only(bottom: 8),
+          padding: const EdgeInsets.only(bottom: 6),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              // 종목 범례
-              ...tickers.map((t) => Padding(
-                padding: const EdgeInsets.only(left: 10),
-                child: Row(
-                  children: [
-                    Container(width: 10, height: 2.5, color: tickerColor(t)),
-                    const SizedBox(width: 3),
-                    Text(
-                      _scaledTickers.contains(t) ? '$t×10' : t,
-                      style: const TextStyle(fontSize: 9, color: Color(0xFF6B7684)),
-                    ),
-                  ],
-                ),
-              )),
-              // 자산 범례
-              if (hasAsset) ...[
-                const SizedBox(width: 10),
-                Container(width: 10, height: 2.5, color: const Color(0xFF111111)),
-                const SizedBox(width: 3),
-                const Text('내 자산', style: TextStyle(fontSize: 9, color: Color(0xFF6B7684))),
-              ],
+              _legendDot(const Color(0xFF1971C2), 'S&P 500'),
+              const SizedBox(width: 12),
+              if (hasAsset) _legendDot(const Color(0xFF111111), '내 자산'),
             ],
           ),
         ),
@@ -217,22 +153,22 @@ class StockChart extends StatelessWidget {
         Expanded(
           child: LineChart(
             LineChartData(
-              minY: _minY,
-              maxY: _maxY,
+              minY: minY,
+              maxY: maxY,
               minX: 0,
               maxX: (rounds.length - 1).toDouble(),
-
               lineBarsData: lineBars,
-
               gridData: FlGridData(
                 show: true,
                 drawVerticalLine: false,
-                horizontalInterval: (_maxY - _minY) / 4,
-                getDrawingHorizontalLine: (_) => const FlLine(
-                  color: Color(0xFFEEEEEE), strokeWidth: 1,
+                horizontalInterval: interval,
+                getDrawingHorizontalLine: (value) => FlLine(
+                  color: value.abs() < 0.01
+                      ? const Color(0xFFCCCCCC)
+                      : const Color(0xFFEEEEEE),
+                  strokeWidth: value.abs() < 0.01 ? 1.0 : 0.5,
                 ),
               ),
-
               borderData: FlBorderData(
                 show: true,
                 border: const Border(
@@ -240,56 +176,87 @@ class StockChart extends StatelessWidget {
                   left:   BorderSide(color: Color(0xFFEEEEEE), width: 1),
                 ),
               ),
-
-              // Y축 숫자 제거
+              // 0% 기준 점선
+              extraLinesData: ExtraLinesData(
+                horizontalLines: [
+                  HorizontalLine(
+                    y: 0,
+                    color: const Color(0xFFBBBBBB),
+                    strokeWidth: 1,
+                    dashArray: [4, 4],
+                  ),
+                ],
+              ),
               titlesData: FlTitlesData(
+                // Y축: 수익률 %
+                leftTitles: AxisTitles(
+                  sideTitles: SideTitles(
+                    showTitles: true,
+                    reservedSize: 38,
+                    interval: interval,
+                    getTitlesWidget: (value, _) => Padding(
+                      padding: const EdgeInsets.only(right: 4),
+                      child: Text(
+                        '${value >= 0 ? '+' : ''}${value.toStringAsFixed(0)}%',
+                        style: const TextStyle(
+                          fontSize: 8,
+                          color: Color(0xFF6B7684),
+                        ),
+                        textAlign: TextAlign.right,
+                      ),
+                    ),
+                  ),
+                ),
+                rightTitles: const AxisTitles(
+                    sideTitles: SideTitles(showTitles: false)),
+                topTitles: const AxisTitles(
+                    sideTitles: SideTitles(showTitles: false)),
+                // X축: 날짜
                 bottomTitles: AxisTitles(
                   sideTitles: SideTitles(
                     showTitles: true,
-                    reservedSize: 24,
-                    interval: (rounds.length / 5).ceilToDouble(),
+                    reservedSize: 22,
+                    interval: (rounds.length / 4).ceilToDouble(),
                     getTitlesWidget: (value, _) {
-                      final index = value.toInt();
-                      if (index < 0 || index >= rounds.length) {
+                      final idx = value.toInt();
+                      if (idx < 0 || idx >= rounds.length) {
                         return const SizedBox.shrink();
                       }
-                      final date = rounds[index].date;
-                      final parts = date.split('-');
+                      final parts = rounds[idx].date.split('-');
                       final label = parts.length >= 3
                           ? '${parts[1]}/${parts[2]}'
-                          : date;
+                          : rounds[idx].date;
                       return Padding(
                         padding: const EdgeInsets.only(top: 4),
-                        child: Text(label, style: const TextStyle(
-                          fontSize: 9, color: Color(0xFF6B7684),
-                        )),
+                        child: Text(label,
+                            style: const TextStyle(
+                                fontSize: 8, color: Color(0xFF6B7684))),
                       );
                     },
                   ),
-                ),
-                leftTitles:  const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-                topTitles:   const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-                rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-              ),
-
-              lineTouchData: LineTouchData(
-                touchTooltipData: LineTouchTooltipData(
-                  getTooltipItems: (spots) => spots.map((spot) {
-                    final index = spot.x.toInt();
-                    final date = index < rounds.length ? rounds[index].date : '';
-                    return LineTooltipItem(
-                      '$date\n${spot.y.toStringAsFixed(0)}',
-                      const TextStyle(
-                        color: Colors.white, fontSize: 10,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    );
-                  }).toList(),
                 ),
               ),
             ),
           ),
         ),
+      ],
+    );
+  }
+
+  Widget _legendDot(Color color, String label) {
+    return Row(
+      children: [
+        Container(
+          width: 12,
+          height: 2.5,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(1),
+          ),
+        ),
+        const SizedBox(width: 3),
+        Text(label,
+            style: const TextStyle(fontSize: 9, color: Color(0xFF6B7684))),
       ],
     );
   }

--- a/frontEnd/lib/widgets/stock_chart.dart
+++ b/frontEnd/lib/widgets/stock_chart.dart
@@ -2,7 +2,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import '../models/round_data.dart';
 
-class StockChart extends StatelessWidget {
+class StockChart extends StatefulWidget {
   final List<RoundData> rounds;
   final double initialAsset;
 
@@ -12,38 +12,42 @@ class StockChart extends StatelessWidget {
     this.initialAsset = 10000000,
   });
 
-  // SPX 첫날 종가 (정규화 기준점)
+  @override
+  State<StockChart> createState() => _StockChartState();
+}
+
+class _StockChartState extends State<StockChart> {
+  int? _touchedIndex;
+
   double? get _spxBase {
-    for (final r in rounds) {
+    for (final r in widget.rounds) {
       final p = r.getPrice('^SPX');
       if (p != null && p.close > 0) return p.close;
     }
     return null;
   }
 
-  // S&P500 수익률(%) FlSpot 리스트
   List<FlSpot> get _spxSpots {
     final base = _spxBase;
     if (base == null) return [];
     final spots = <FlSpot>[];
-    for (int i = 0; i < rounds.length; i++) {
-      final p = rounds[i].getPrice('^SPX');
+    for (int i = 0; i < widget.rounds.length; i++) {
+      final p = widget.rounds[i].getPrice('^SPX');
       if (p != null) {
-        final pct = (p.close - base) / base * 100;
-        spots.add(FlSpot(i.toDouble(), pct));
+        spots.add(FlSpot(i.toDouble(), (p.close - base) / base * 100));
       }
     }
     return spots;
   }
 
-  // 내 자산 수익률(%) FlSpot 리스트
   List<FlSpot> get _assetSpots {
     final spots = <FlSpot>[];
-    for (int i = 0; i < rounds.length; i++) {
-      final asset = rounds[i].roundAsset;
+    for (int i = 0; i < widget.rounds.length; i++) {
+      final asset = widget.rounds[i].roundAsset;
       if (asset != null) {
-        final pct = (asset - initialAsset) / initialAsset * 100;
-        spots.add(FlSpot(i.toDouble(), pct));
+        spots.add(FlSpot(
+            i.toDouble(),
+            (asset - widget.initialAsset) / widget.initialAsset * 100));
       }
     }
     return spots;
@@ -54,7 +58,6 @@ class StockChart extends StatelessWidget {
     for (final s in [..._spxSpots, ..._assetSpots]) {
       if (s.y < min) min = s.y;
     }
-    // 여유분 10% + 최소 -2%
     return ((min * 1.15) - 2).floorToDouble();
   }
 
@@ -68,7 +71,7 @@ class StockChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (rounds.isEmpty) {
+    if (widget.rounds.isEmpty) {
       return const Center(
         child: Text('데이터 없음',
             style: TextStyle(color: Color(0xFF6B7684))),
@@ -83,57 +86,6 @@ class StockChart extends StatelessWidget {
     final range      = (maxY - minY).abs();
     final interval   = range > 0 ? (range / 4) : 2.0;
 
-    final lineBars = <LineChartBarData>[
-      // S&P 500 (파랑)
-      if (spxSpots.isNotEmpty)
-        LineChartBarData(
-          spots: spxSpots,
-          color: const Color(0xFF1971C2),
-          barWidth: 1.5,
-          isCurved: true,
-          curveSmoothness: 0.3,
-          dotData: FlDotData(
-            show: true,
-            getDotPainter: (spot, _, __, idx) {
-              final last = idx == spxSpots.length - 1;
-              return FlDotCirclePainter(
-                radius: last ? 3 : 0,
-                color: const Color(0xFF1971C2),
-                strokeWidth: last ? 2 : 0,
-                strokeColor: Colors.white,
-              );
-            },
-          ),
-          belowBarData: BarAreaData(show: false),
-        ),
-
-      // 내 자산 (검정)
-      if (hasAsset)
-        LineChartBarData(
-          spots: assetSpots,
-          color: const Color(0xFF111111),
-          barWidth: 2.5,
-          isCurved: true,
-          curveSmoothness: 0.3,
-          dotData: FlDotData(
-            show: true,
-            getDotPainter: (spot, _, __, idx) {
-              final last = idx == assetSpots.length - 1;
-              return FlDotCirclePainter(
-                radius: last ? 4 : 0,
-                color: const Color(0xFF111111),
-                strokeWidth: last ? 2 : 0,
-                strokeColor: Colors.white,
-              );
-            },
-          ),
-          belowBarData: BarAreaData(
-            show: true,
-            color: const Color(0xFF111111).withValues(alpha: 0.04),
-          ),
-        ),
-    ];
-
     return Column(
       children: [
         // 범례
@@ -142,22 +94,113 @@ class StockChart extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              _legendDot(const Color(0xFF1971C2), 'S&P 500'),
+              _legendItemDash(const Color(0xFF74B0FF), 'S&P 500'),
               const SizedBox(width: 12),
-              if (hasAsset) _legendDot(const Color(0xFF111111), '내 자산'),
+              if (hasAsset)
+                _legendItem(const Color(0xFF3C3489), '내 자산'),
             ],
           ),
         ),
 
-        // 차트
         Expanded(
           child: LineChart(
             LineChartData(
               minY: minY,
               maxY: maxY,
               minX: 0,
-              maxX: (rounds.length - 1).toDouble(),
-              lineBarsData: lineBars,
+              maxX: (widget.rounds.length - 1).toDouble(),
+              lineTouchData: LineTouchData(
+                enabled: true,
+                touchCallback: (event, response) {
+                  setState(() {
+                    if (response?.lineBarSpots != null &&
+                        response!.lineBarSpots!.isNotEmpty) {
+                      _touchedIndex =
+                          response.lineBarSpots!.first.spotIndex;
+                    } else {
+                      _touchedIndex = null;
+                    }
+                  });
+                },
+                touchTooltipData: LineTouchTooltipData(
+                  getTooltipColor: (_) => const Color(0xFF1A1A2E),
+                  getTooltipItems: (spots) {
+                    return spots.map((spot) {
+                      final label = spot.barIndex == 0
+                          ? 'S&P500'
+                          : '내 자산';
+                      final val = spot.y;
+                      return LineTooltipItem(
+                        '$label\n${val >= 0 ? '+' : ''}${val.toStringAsFixed(2)}%',
+                        TextStyle(
+                          color: spot.barIndex == 0
+                              ? const Color(0xFF74B0FF)
+                              : Colors.white,
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      );
+                    }).toList();
+                  },
+                ),
+              ),
+              lineBarsData: [
+                // S&P 500
+                if (spxSpots.isNotEmpty)
+                  LineChartBarData(
+                    spots: spxSpots,
+                    color: const Color(0xFF74B0FF),
+                    barWidth: 1.5,
+                    isCurved: true,
+                    curveSmoothness: 0.3,
+                    dashArray: [6, 4],
+                    dotData: FlDotData(
+                      show: true,
+                      getDotPainter: (spot, _, __, idx) {
+                        final last = idx == spxSpots.length - 1;
+                        return FlDotCirclePainter(
+                          radius: last ? 2.5 : 0,
+                          color: const Color(0xFF74B0FF),
+                          strokeWidth: last ? 1.5 : 0,
+                          strokeColor: Colors.white,
+                        );
+                      },
+                    ),
+                    belowBarData: BarAreaData(show: false),
+                  ),
+                // 내 자산
+                if (hasAsset)
+                  LineChartBarData(
+                    spots: assetSpots,
+                    color: const Color(0xFF3C3489),
+                    barWidth: 2.5,
+                    isCurved: true,
+                    curveSmoothness: 0.3,
+                    dotData: FlDotData(
+                      show: true,
+                      getDotPainter: (spot, _, __, idx) {
+                        final last = idx == assetSpots.length - 1;
+                        return FlDotCirclePainter(
+                          radius: last ? 4 : 0,
+                          color: const Color(0xFF3C3489),
+                          strokeWidth: last ? 2 : 0,
+                          strokeColor: Colors.white,
+                        );
+                      },
+                    ),
+                    belowBarData: BarAreaData(
+                      show: true,
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          const Color(0xFF3C3489).withValues(alpha: 0.18),
+                          const Color(0xFF3C3489).withValues(alpha: 0.02),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
               gridData: FlGridData(
                 show: true,
                 drawVerticalLine: false,
@@ -169,14 +212,6 @@ class StockChart extends StatelessWidget {
                   strokeWidth: value.abs() < 0.01 ? 1.0 : 0.5,
                 ),
               ),
-              borderData: FlBorderData(
-                show: true,
-                border: const Border(
-                  bottom: BorderSide(color: Color(0xFFEEEEEE), width: 1),
-                  left:   BorderSide(color: Color(0xFFEEEEEE), width: 1),
-                ),
-              ),
-              // 0% 기준 점선
               extraLinesData: ExtraLinesData(
                 horizontalLines: [
                   HorizontalLine(
@@ -187,8 +222,14 @@ class StockChart extends StatelessWidget {
                   ),
                 ],
               ),
+              borderData: FlBorderData(
+                show: true,
+                border: const Border(
+                  bottom: BorderSide(color: Color(0xFFEEEEEE), width: 1),
+                  left:   BorderSide(color: Color(0xFFEEEEEE), width: 1),
+                ),
+              ),
               titlesData: FlTitlesData(
-                // Y축: 수익률 %
                 leftTitles: AxisTitles(
                   sideTitles: SideTitles(
                     showTitles: true,
@@ -199,9 +240,7 @@ class StockChart extends StatelessWidget {
                       child: Text(
                         '${value >= 0 ? '+' : ''}${value.toStringAsFixed(0)}%',
                         style: const TextStyle(
-                          fontSize: 8,
-                          color: Color(0xFF6B7684),
-                        ),
+                            fontSize: 8, color: Color(0xFF6B7684)),
                         textAlign: TextAlign.right,
                       ),
                     ),
@@ -211,21 +250,20 @@ class StockChart extends StatelessWidget {
                     sideTitles: SideTitles(showTitles: false)),
                 topTitles: const AxisTitles(
                     sideTitles: SideTitles(showTitles: false)),
-                // X축: 날짜
                 bottomTitles: AxisTitles(
                   sideTitles: SideTitles(
                     showTitles: true,
                     reservedSize: 22,
-                    interval: (rounds.length / 4).ceilToDouble(),
+                    interval: (widget.rounds.length / 4).ceilToDouble(),
                     getTitlesWidget: (value, _) {
                       final idx = value.toInt();
-                      if (idx < 0 || idx >= rounds.length) {
+                      if (idx < 0 || idx >= widget.rounds.length) {
                         return const SizedBox.shrink();
                       }
-                      final parts = rounds[idx].date.split('-');
+                      final parts = widget.rounds[idx].date.split('-');
                       final label = parts.length >= 3
                           ? '${parts[1]}/${parts[2]}'
-                          : rounds[idx].date;
+                          : widget.rounds[idx].date;
                       return Padding(
                         padding: const EdgeInsets.only(top: 4),
                         child: Text(label,
@@ -243,21 +281,62 @@ class StockChart extends StatelessWidget {
     );
   }
 
-  Widget _legendDot(Color color, String label) {
+  Widget _legendItem(Color color, String label) {
     return Row(
       children: [
         Container(
           width: 12,
           height: 2.5,
           decoration: BoxDecoration(
-            color: color,
-            borderRadius: BorderRadius.circular(1),
+              color: color, borderRadius: BorderRadius.circular(1)),
+        ),
+        const SizedBox(width: 3),
+        Text(label,
+            style: const TextStyle(
+                fontSize: 9, color: Color(0xFF6B7684))),
+      ],
+    );
+  }
+
+  // 점선 범례 (S&P500용)
+  Widget _legendItemDash(Color color, String label) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 14,
+          height: 8,
+          child: CustomPaint(
+            painter: _DashPainter(color: color),
           ),
         ),
         const SizedBox(width: 3),
         Text(label,
-            style: const TextStyle(fontSize: 9, color: Color(0xFF6B7684))),
+            style: const TextStyle(
+                fontSize: 9, color: Color(0xFF6B7684))),
       ],
     );
   }
+}
+
+// 점선 범례 페인터
+class _DashPainter extends CustomPainter {
+  final Color color;
+  _DashPainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = 1.5
+      ..strokeCap = StrokeCap.round;
+    double x = 0;
+    while (x < size.width) {
+      canvas.drawLine(Offset(x, size.height / 2),
+          Offset((x + 4).clamp(0, size.width), size.height / 2), paint);
+      x += 7;
+    }
+  }
+
+  @override
+  bool shouldRepaint(_DashPainter old) => old.color != color;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #58 

## 📝 작업 내용

API 명세서 v4.0에 따라 Flutter AI 추천 UI를 구현하고
차트 및 보유종목 위젯을 전면 개편하였습니다.

## 📁 변경된 파일

| 파일 | 변경 내용 |
|------|-----------|
| `lib/models/v1_recommend_result.dart` | 신규 — V1.5 추천 결과 모델 |
| `lib/models/v2_recommend_result.dart` | 신규 — V2 추천 결과 모델 |
| `lib/widgets/holdings_widget.dart` | 신규 — 보유종목 스파크라인/그리드 위젯 |
| `lib/services/game_service.dart` | 수정 — V1/V2 추천 API 메서드 추가 |
| `lib/widgets/stock_chart.dart` | 수정 — 수익률% 2선 차트로 전면 개편 |
| `lib/screens/game_screen.dart` | 수정 — AI 추천 버튼, 보유종목 연동 |

## 🔍 주요 로직

### AI 추천 버튼 상태 흐름

```dart
enum AiState { idle, loading, done, error }

// idle: ✨ AI 추천받기 (보라)
// loading: ⏳ 분석 중... (연보라 + 로딩바)
// done: ✅ 추천 완료 (초록) + 뱃지 + 기여도 표시
// error: ⚠️ 다시 시도 (빨강)
```

### 라운드별 추천 방식

| 라운드 | 추천 | 이유 |
|--------|------|------|
| 1라운드 | V1.5 백그라운드 | so_far = 0 |
| 25라운드 | V2 실시간 | ρ=+0.53 |
| 50라운드 | V2 실시간 | so_far 정보 풍부 |
| 75라운드 | V1.5 백그라운드 | ρ=-0.12 역상관 |

### 보유종목 위젯 조건부 렌더링

```dart
if (_showCard) ...[
  HoldingsMiniGrid(holdings: _holdings),  // 카드선택: 2x2 그리드
  _buildCardSelector(),
] else ...[
  HoldingsGameWidget(holdings: _holdings), // 진행중: 스파크라인
  _buildControls(),
]
```

### 차트 변경

```dart
// 기존: 종목별 다중 선 (x10 배율 혼용)
// 변경: 수익률% 정규화, SPX + 내 자산 2개만

// SPX 수익률
final pct = (close - spxBase) / spxBase * 100;

// 내 자산 수익률
final pct = (asset - initialAsset) / initialAsset * 100;
```

## ✅ 체크리스트

- [x] v1_recommend_result.dart 파싱 검증
- [x] v2_recommend_result.dart 파싱 검증
- [x] AI 버튼 4가지 상태 동작 확인
- [x] 25·50라운드 V2 호출, 1·75라운드 V1.5 폴백
- [x] 기여도 버튼 눌렀을 때만 표시
- [x] 보유종목 1~4개 레이아웃 확인
- [x] 새 종목 보라 테두리 표시
- [x] 차트 Y축 수익률% 표시
- [x] 시장 대비 배너 표시
- [x] AI 실패 시 게임 계속 진행 가능 확인

## ⚠️ 참고사항

- V1.5 추천은 게임 시작 시 백그라운드 자동 호출
  (응답 1~2분, 완료 전엔 V1.5 뱃지 미표시)
- V2 추천 실패 시 게임 계속 진행 가능 (optional)
- _selectedCardIds 누적으로 V2 alreadyCards 파라미터 구성

## 🔗 연관된 이슈
close #58 